### PR TITLE
Use maps for options instead of proplists

### DIFF
--- a/src/serde_arrow_array.erl
+++ b/src/serde_arrow_array.erl
@@ -93,7 +93,7 @@
 %% Array Creation %%
 %%%%%%%%%%%%%%%%%%%%
 
--callback new(Value :: [serde_arrow_type:erlang_type()], Opts :: [proplists:property()]) ->
+-callback new(Value :: [serde_arrow_type:erlang_type()], Opts :: map()) ->
     Array :: #array{}.
 %% Creates a new array of a certain layout, given its value and options.
 
@@ -101,7 +101,7 @@
 -spec new(
     Layout :: layout(),
     Value :: [serde_arrow_type:erlang_type()],
-    Opts :: [proplists:property()]
+    Opts :: map()
 ) ->
     Array :: #array{}.
 new(Layout, Value, Opts) ->

--- a/src/serde_arrow_fixed_primitive_array.erl
+++ b/src/serde_arrow_fixed_primitive_array.erl
@@ -48,11 +48,11 @@
 %% @end
 -spec new(
     Value :: [serde_arrow_type:erlang_type()],
-    Type :: [proplist:property()] | serde_arrow_type:arrow_type()
+    Type :: map() | serde_arrow_type:arrow_type()
 ) ->
     Array :: #array{}.
-new(Value, Opts) when is_list(Opts) ->
-    case proplists:get_value(type, Opts) of
+new(Value, Opts) when is_map(Opts) ->
+    case maps:get(type, Opts, undefined) of
         undefined ->
             erlang:error(badarg);
         Type when is_tuple(Type) orelse is_atom(Type) ->

--- a/src/serde_arrow_variable_binary_array.erl
+++ b/src/serde_arrow_variable_binary_array.erl
@@ -12,7 +12,7 @@
 
 %% @doc Creates a Variable-Sized Binary Array given the values and options in the form of
 %% a proplist
--spec new(Values :: [serde_arrow_type:erlang_type()], Opts :: list()) -> Array :: #array{}.
+-spec new(Values :: [serde_arrow_type:erlang_type()], Opts :: map()) -> Array :: #array{}.
 new(Values, _Opts) ->
     new(Values).
 

--- a/test/serde_arrow_array_SUITE.erl
+++ b/test/serde_arrow_array_SUITE.erl
@@ -27,11 +27,11 @@ all() ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 
 valid_array_on_new(_Config) ->
-    Given1 = serde_arrow_array:new(fixed_primitive, [1, 2, 3], [{type, {s, 8}}]),
+    Given1 = serde_arrow_array:new(fixed_primitive, [1, 2, 3], #{type => {s, 8}}),
     Expected1 = serde_arrow_fixed_primitive_array:new([1, 2, 3], {s, 8}),
     ?assertEqual(Given1, Expected1),
 
-    Given2 = serde_arrow_array:new(variable_binary, [<<1>>, <<2>>], []),
+    Given2 = serde_arrow_array:new(variable_binary, [<<1>>, <<2>>], #{}),
     Expected2 = serde_arrow_variable_binary_array:new([<<1>>, <<2>>]),
     ?assertEqual(Given2, Expected2).
 

--- a/test/serde_arrow_fixed_primitive_array_SUITE.erl
+++ b/test/serde_arrow_fixed_primitive_array_SUITE.erl
@@ -120,7 +120,7 @@ valid_data_on_new(_Config) ->
 
 new_callback(_Config) ->
     Array = serde_arrow_fixed_primitive_array:new([1, 2], {s, 8}),
-    Callback = serde_arrow_fixed_primitive_array:new([1, 2], [{type, {s, 8}}]),
+    Callback = serde_arrow_fixed_primitive_array:new([1, 2], #{type => {s, 8}}),
     ?assertEqual(Callback, Array),
 
-    ?assertError(badarg, serde_arrow_fixed_primitive_array:new([1, 2], [])).
+    ?assertError(badarg, serde_arrow_fixed_primitive_array:new([1, 2], #{foo => bar})).

--- a/test/serde_arrow_variable_binary_array_SUITE.erl
+++ b/test/serde_arrow_variable_binary_array_SUITE.erl
@@ -106,5 +106,5 @@ valid_data_on_new(_Config) ->
 
 new_callback(_Config) ->
     Array = serde_arrow_variable_binary_array:new([<<1>>, <<2>>]),
-    Callback = serde_arrow_variable_binary_array:new([<<1>>, <<2>>], []),
+    Callback = serde_arrow_variable_binary_array:new([<<1>>, <<2>>], #{}),
     ?assertEqual(Callback, Array).


### PR DESCRIPTION
Using proplists for options is an old convention in Erlang. The current
standard is to use maps instead. This commit makes that switch. This
commit specifically affects the behaviour of serde_arrow_array:new/3's
behaviour and the new/2 callback.
