### PR TITLE
Add serde_arrow_buffer:from_arrow/3

### DIFF
--- a/src/serde_arrow_buffer.hrl
+++ b/src/serde_arrow_buffer.hrl
@@ -1,5 +1,5 @@
 -record(buffer, {
     type :: serde_arrow_type:arrow_longhand_type(),
     length :: pos_integer(),
-    data :: binary()
+    data :: [serde_arrow_type:native_type()] | binary()
 }).


### PR DESCRIPTION
- Add from_erlang/2 to serde_arrow_buffer
- Add to_arrow/2
- Add to_arrow docs
- Add to_erlang/1
- Store binary data as a single binary in a buffer
- Add incomplete implementation of from_arrow
