### PR TITLE
Allow length to be passed into buffer:from_erlang

### DIFF
--- a/src/serde_arrow_buffer.erl
+++ b/src/serde_arrow_buffer.erl
@@ -63,7 +63,7 @@ from_erlang(Data, Type) ->
 -spec from_erlang(
     Data :: [serde_arrow_type:native_type()] | binary(),
     Type :: serde_arrow_type:arrow_longhand_type(),
-    DataLen :: pos_integer()
+    DataLen :: pos_integer() | undefined
 ) ->
     Buffer :: #buffer{}.
 from_erlang(Data, Type, DataLen) ->

--- a/src/serde_arrow_buffer.erl
+++ b/src/serde_arrow_buffer.erl
@@ -35,7 +35,7 @@
 %% [2]: [https://arrow.apache.org/docs/format/Glossary.html#term-slot]
 %% @end
 -module(serde_arrow_buffer).
--export([from_erlang/2, to_arrow/1, to_erlang/1]).
+-export([from_erlang/2, from_erlang/3, to_arrow/1, to_erlang/1]).
 
 -include("serde_arrow_buffer.hrl").
 
@@ -50,12 +50,31 @@
 from_erlang(Data, Type) ->
     Len =
         case Type of
+            {bin, undefined} ->
+                undefined;
+            _ ->
+                length(Data)
+        end,
+    from_erlang(Data, Type, Len).
+
+%% @doc Creates a new buffer from a list of Erlang values or binaries, given its
+%% type and length
+%% @end
+-spec from_erlang(
+    Data :: [serde_arrow_type:native_type()] | binary(),
+    Type :: serde_arrow_type:arrow_longhand_type(),
+    DataLen :: pos_integer()
+) ->
+    Buffer :: #buffer{}.
+from_erlang(Data, Type, DataLen) ->
+    Len =
+        case Type of
             {bin, undefined} when is_binary(Data) ->
                 byte_size(Data);
             {bin, undefined} ->
                 erlang:error(badarg);
             _ ->
-                length(Data) * serde_arrow_type:byte_length(Type)
+                DataLen * serde_arrow_type:byte_length(Type)
         end,
     #buffer{type = Type, length = Len, data = Data}.
 

--- a/src/serde_arrow_fixed_primitive_array.erl
+++ b/src/serde_arrow_fixed_primitive_array.erl
@@ -62,7 +62,7 @@ new(Value, GivenType) when is_tuple(GivenType) orelse is_atom(GivenType) ->
     Len = length(Value),
     Type = serde_arrow_type:normalize(GivenType),
     {Bitmap, NullCount} = serde_arrow_bitmap:validity_bitmap(Value),
-    Data = serde_arrow_buffer:from_erlang(Value, Type),
+    Data = serde_arrow_buffer:from_erlang(Value, Type, Len),
     #array{
         layout = fixed_primitive,
         type = Type,

--- a/src/serde_arrow_offsets.erl
+++ b/src/serde_arrow_offsets.erl
@@ -40,7 +40,7 @@
 %% [2]: [https://arrow.apache.org/docs/format/Columnar.html#terminology]
 %% @end
 -module(serde_arrow_offsets).
--export([new/2]).
+-export([new/2, new/3]).
 
 -include("serde_arrow_buffer.hrl").
 
@@ -51,8 +51,18 @@
 ) ->
     Buffer :: #buffer{}.
 new(Values, Type) ->
+    new(Values, Type, length(Values)).
+
+%% @doc Returns the offsets array given some values, their type and length as a buffer.
+-spec new(
+    Value :: [serde_arrow_type:native_type()],
+    Type :: serde_arrow_type:arrow_longhand_type(),
+    Length :: pos_integer()
+) ->
+    Buffer :: #buffer{}.
+new(Values, Type, Len) ->
     Offsets = offsets(Values, [0], 0, Type),
-    serde_arrow_buffer:from_erlang(Offsets, {s, 32}).
+    serde_arrow_buffer:from_erlang(Offsets, {s, 32}, Len + 1).
 
 -spec offsets(
     Value :: [serde_arrow_type:native_type()],

--- a/src/serde_arrow_variable_binary_array.erl
+++ b/src/serde_arrow_variable_binary_array.erl
@@ -21,7 +21,7 @@ new(Values, _Opts) ->
 new(Values) ->
     Len = length(Values),
     {Bitmap, NullCount} = serde_arrow_bitmap:validity_bitmap(Values),
-    Offsets = serde_arrow_offsets:new(Values, {bin, undefined}),
+    Offsets = serde_arrow_offsets:new(Values, {bin, undefined}, Len),
     Bin = <<X || X <- Values, X =/= undefined, X =/= nil>>,
     Data = serde_arrow_buffer:from_erlang(Bin, {bin, undefined}),
     #array{

--- a/src/serde_arrow_variable_list_array.erl
+++ b/src/serde_arrow_variable_list_array.erl
@@ -54,11 +54,11 @@ new(Values, GivenType) ->
     FlatOffsets =
         case Data#array.offsets of
             undefined ->
-                fixed_offsets(Type, length(Flattened));
+                fixed_offsets(Type, Data#array.len);
             Offset ->
                 Offset#buffer.data
         end,
-    Offsets = serde_arrow_buffer:from_erlang(offsets(Values, FlatOffsets, 0), {s, 32}),
+    Offsets = serde_arrow_buffer:from_erlang(offsets(Values, FlatOffsets, 0), {s, 32}, Len + 1),
     #array{
         layout = variable_list,
         type = Type,

--- a/test/serde_arrow_buffer_SUITE.erl
+++ b/test/serde_arrow_buffer_SUITE.erl
@@ -30,9 +30,15 @@ valid_length_on_from_erlang(_Config) ->
     Buffer1 = serde_arrow_buffer:from_erlang([1, 2, undefined, 3, nil], {s, 8}),
     ?assertEqual(Buffer1#buffer.length, 5),
 
+    Buffer2 = serde_arrow_buffer:from_erlang([1, 2, undefined, 3, nil], {s, 8}, 5),
+    ?assertEqual(Buffer2#buffer.length, 5),
+
     %% With binaries
-    Buffer2 = serde_arrow_buffer:from_erlang(<<1, 2, 3>>, {bin, undefined}),
-    ?assertEqual(Buffer2#buffer.length, 3).
+    Buffer3 = serde_arrow_buffer:from_erlang(<<1, 2, 3>>, {bin, undefined}),
+    ?assertEqual(Buffer3#buffer.length, 3),
+
+    Buffer4 = serde_arrow_buffer:from_erlang(<<1, 2, 3>>, {bin, undefined}, 3),
+    ?assertEqual(Buffer4#buffer.length, 3).
 
 valid_type_on_from_erlang(_Config) ->
     Buffer1 = serde_arrow_buffer:from_erlang([1, 2, 3], {s, 32}),


### PR DESCRIPTION
This allows us to not call length unnecessarily, when we already know
the length of a value, improving performance.
