### PR TITLE
Rename array:new to array:from_erlang

### DIFF
--- a/src/serde_arrow_array.erl
+++ b/src/serde_arrow_array.erl
@@ -54,8 +54,8 @@
 %%
 %% == The Behaviour of an Array ==
 %%
-%% As of right now, a layout needs to implement the `c:new/2' callback. This is
-%% then used in the `new/3' function to create new arrays.
+%% As of right now, a layout needs to implement the `c:from_erlang/2' callback. This is
+%% then used in the `from_erlang/3' function to create new arrays.
 %%
 %% == Functions for working with Arrays ==
 %%
@@ -80,7 +80,7 @@
 %% @end
 -module(serde_arrow_array).
 -export([
-    new/3,
+    from_erlang/3,
     layout/1,
     type/1,
     len/1,
@@ -101,23 +101,25 @@
 %% Array Creation %%
 %%%%%%%%%%%%%%%%%%%%
 
--callback new(Value :: [serde_arrow_type:native_type()], Opts :: map()) ->
+-callback from_erlang(Value :: [serde_arrow_type:native_type()], Opts :: map()) ->
     Array :: #array{}.
-%% Creates a new array of a certain layout, given its value and options.
+%% Creates a new array of a certain layout, given its value and options from its
+%% erlang representation.
 
 %% @doc A common way to create a new array, given its layout, value, and options.
--spec new(
+%% from its erlang representation.
+-spec from_erlang(
     Layout :: layout(),
     Value :: [serde_arrow_type:native_type()],
     Opts :: map() | serde_arrow_type:arrow_type()
 ) ->
     Array :: #array{}.
-new(Layout, Value, Opts) ->
+from_erlang(Layout, Value, Opts) ->
     case Layout of
-        fixed_primitive -> serde_arrow_fixed_primitive_array:new(Value, Opts);
-        variable_binary -> serde_arrow_variable_binary_array:new(Value, Opts);
-        fixed_list -> serde_arrow_fixed_list_array:new(Value, Opts);
-        variable_list -> serde_arrow_variable_list_array:new(Value, Opts)
+        fixed_primitive -> serde_arrow_fixed_primitive_array:from_erlang(Value, Opts);
+        variable_binary -> serde_arrow_variable_binary_array:from_erlang(Value, Opts);
+        fixed_list -> serde_arrow_fixed_list_array:from_erlang(Value, Opts);
+        variable_list -> serde_arrow_variable_list_array:from_erlang(Value, Opts)
     end.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/serde_arrow_fixed_primitive_array.erl
+++ b/src/serde_arrow_fixed_primitive_array.erl
@@ -34,7 +34,7 @@
 -module(serde_arrow_fixed_primitive_array).
 -behaviour(serde_arrow_array).
 
--export([new/2]).
+-export([from_erlang/2]).
 
 -include("serde_arrow_array.hrl").
 
@@ -42,23 +42,24 @@
 %% Array Creation %%
 %%%%%%%%%%%%%%%%%%%%
 
-%% @doc Creates a new primitive array, given its value and type.
+%% @doc Creates a new primitive array, given its value and type from its erlang
+%% representation.
 %%
 %% Accepts a map with the type, or the type directly.
 %% @end
--spec new(
+-spec from_erlang(
     Value :: [serde_arrow_type:native_type()],
     Type :: map() | serde_arrow_type:arrow_primitive_type()
 ) ->
     Array :: #array{}.
-new(Value, Opts) when is_map(Opts) ->
+from_erlang(Value, Opts) when is_map(Opts) ->
     case maps:get(type, Opts, undefined) of
         undefined ->
             erlang:error(badarg);
         Type when is_tuple(Type) orelse is_atom(Type) ->
-            new(Value, Type)
+            from_erlang(Value, Type)
     end;
-new(Value, GivenType) when is_tuple(GivenType) orelse is_atom(GivenType) ->
+from_erlang(Value, GivenType) when is_tuple(GivenType) orelse is_atom(GivenType) ->
     Len = length(Value),
     Type = serde_arrow_type:normalize(GivenType),
     {Bitmap, NullCount} = serde_arrow_bitmap:validity_bitmap(Value),

--- a/src/serde_arrow_variable_binary_array.erl
+++ b/src/serde_arrow_variable_binary_array.erl
@@ -6,19 +6,19 @@
 -module(serde_arrow_variable_binary_array).
 -behaviour(serde_arrow_array).
 
--export([new/1, new/2]).
+-export([from_erlang/1, from_erlang/2]).
 
 -include("serde_arrow_array.hrl").
 
 %% @doc Creates a Variable-Sized Binary Array given the values and options in the form of
-%% a map
--spec new(Values :: [serde_arrow_type:native_type()], Opts :: map()) -> Array :: #array{}.
-new(Values, _Opts) ->
-    new(Values).
+%% a map, from its erlang representation.
+-spec from_erlang(Values :: [serde_arrow_type:native_type()], Opts :: map()) -> Array :: #array{}.
+from_erlang(Values, _Opts) ->
+    from_erlang(Values).
 
 %% @doc Creates a Variable-Sized Binary Array given the values
--spec new(Values :: [serde_arrow_type:native_type()]) -> Array :: #array{}.
-new(Values) ->
+-spec from_erlang(Values :: [serde_arrow_type:native_type()]) -> Array :: #array{}.
+from_erlang(Values) ->
     Len = length(Values),
     {Bitmap, NullCount} = serde_arrow_bitmap:validity_bitmap(Values),
     Offsets = serde_arrow_offsets:new(Values, {bin, undefined}, Len),

--- a/test/serde_arrow_array_SUITE.erl
+++ b/test/serde_arrow_array_SUITE.erl
@@ -10,7 +10,7 @@
 all() ->
     [
         %% creation tests
-        valid_array_on_new,
+        valid_array_on_from_erlang,
 
         %% data and metadata tests
         valid_layout_on_access,
@@ -27,13 +27,13 @@ all() ->
 %% Array Creation Tests %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 
-valid_array_on_new(_Config) ->
-    Given1 = serde_arrow_array:new(fixed_primitive, [1, 2, 3], #{type => {s, 8}}),
-    Expected1 = serde_arrow_fixed_primitive_array:new([1, 2, 3], {s, 8}),
+valid_array_on_from_erlang(_Config) ->
+    Given1 = serde_arrow_array:from_erlang(fixed_primitive, [1, 2, 3], #{type => {s, 8}}),
+    Expected1 = serde_arrow_fixed_primitive_array:from_erlang([1, 2, 3], {s, 8}),
     ?assertEqual(Given1, Expected1),
 
-    Given2 = serde_arrow_array:new(variable_binary, [<<1>>, <<2>>], #{}),
-    Expected2 = serde_arrow_variable_binary_array:new([<<1>>, <<2>>]),
+    Given2 = serde_arrow_array:from_erlang(variable_binary, [<<1>>, <<2>>], #{}),
+    Expected2 = serde_arrow_variable_binary_array:from_erlang([<<1>>, <<2>>]),
     ?assertEqual(Given2, Expected2).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -41,33 +41,33 @@ valid_array_on_new(_Config) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 valid_layout_on_access(_Config) ->
-    Array = serde_arrow_array:new(fixed_primitive, [1, 2, 3], {s, 8}),
+    Array = serde_arrow_array:from_erlang(fixed_primitive, [1, 2, 3], {s, 8}),
     ?assertEqual(serde_arrow_array:layout(Array), fixed_primitive).
 
 valid_type_on_access(_Config) ->
-    Array = serde_arrow_array:new(fixed_primitive, [1, 2, 3], {s, 8}),
+    Array = serde_arrow_array:from_erlang(fixed_primitive, [1, 2, 3], {s, 8}),
     ?assertEqual(serde_arrow_array:type(Array), {s, 8}).
 
 valid_len_on_access(_Config) ->
-    Array = serde_arrow_array:new(fixed_primitive, [1, 2, 3], {s, 8}),
+    Array = serde_arrow_array:from_erlang(fixed_primitive, [1, 2, 3], {s, 8}),
     ?assertEqual(serde_arrow_array:len(Array), 3).
 
 valid_element_len_on_access(_Config) ->
-    Array = serde_arrow_array:new(fixed_primitive, [1, 2, 3], {s, 8}),
+    Array = serde_arrow_array:from_erlang(fixed_primitive, [1, 2, 3], {s, 8}),
     ?assertEqual(serde_arrow_array:element_len(Array), undefined).
 
 valid_null_count_on_access(_Config) ->
-    Array = serde_arrow_array:new(fixed_primitive, [1, 2, 3], {s, 8}),
+    Array = serde_arrow_array:from_erlang(fixed_primitive, [1, 2, 3], {s, 8}),
     ?assertEqual(serde_arrow_array:null_count(Array), 0).
 
 valid_validity_bitmap_on_access(_Config) ->
-    Array = serde_arrow_array:new(fixed_primitive, [1, 2, 3], {s, 8}),
+    Array = serde_arrow_array:from_erlang(fixed_primitive, [1, 2, 3], {s, 8}),
     ?assertEqual(serde_arrow_array:validity_bitmap(Array), undefined).
 
 valid_offsets_on_access(_Config) ->
-    Array = serde_arrow_array:new(fixed_primitive, [1, 2, 3], {s, 8}),
+    Array = serde_arrow_array:from_erlang(fixed_primitive, [1, 2, 3], {s, 8}),
     ?assertEqual(serde_arrow_array:offsets(Array), undefined).
 
 valid_data_on_access(_Config) ->
-    Array = serde_arrow_array:new(fixed_primitive, [1, 2, 3], {s, 8}),
+    Array = serde_arrow_array:from_erlang(fixed_primitive, [1, 2, 3], {s, 8}),
     ?assertEqual(serde_arrow_array:data(Array), serde_arrow_buffer:from_erlang([1, 2, 3], {s, 8})).

--- a/test/serde_arrow_fixed_list_array_SUITE.erl
+++ b/test/serde_arrow_fixed_list_array_SUITE.erl
@@ -9,31 +9,31 @@
 
 all() ->
     [
-        valid_layout_on_new,
-        valid_type_on_new,
-        valid_len_on_new,
-        valid_element_len_on_new,
-        valid_null_count_on_new,
-        valid_validity_bitmap_on_new,
-        valid_offsets_on_new,
-        valid_data_on_new,
-        valid_nested_data_on_new,
+        valid_layout_on_from_erlang,
+        valid_type_on_from_erlang,
+        valid_len_on_from_erlang,
+        valid_element_len_on_from_erlang,
+        valid_null_count_on_from_erlang,
+        valid_validity_bitmap_on_from_erlang,
+        valid_offsets_on_from_erlang,
+        valid_data_on_from_erlang,
+        valid_nested_data_on_from_erlang,
         crashes_on_invalid_data,
         crashes_on_invalid_nesting,
 
         %% Behaviour Adherence
-        new_callback
+        from_erlang_callback
     ].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Fixed List Array Creation Tests %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-valid_layout_on_new(_Config) ->
+valid_layout_on_from_erlang(_Config) ->
     Array = array([[1, 2, 3]], {s, 8}),
     ?assertEqual(Array#array.layout, fixed_list).
 
-valid_type_on_new(_Config) ->
+valid_type_on_from_erlang(_Config) ->
     Array1 = array([[1, 2, 3]], {s, 8}),
     ?assertEqual(Array1#array.type, {s, 8}),
 
@@ -41,15 +41,15 @@ valid_type_on_new(_Config) ->
     Array2 = array([[1, 2, 3]], s8),
     ?assertEqual(Array2#array.type, {s, 8}).
 
-valid_len_on_new(_Config) ->
+valid_len_on_from_erlang(_Config) ->
     Array = array([[1], [2], [3]], {s, 8}),
     ?assertEqual(Array#array.len, 3).
 
-valid_element_len_on_new(_Config) ->
+valid_element_len_on_from_erlang(_Config) ->
     Array = array([[1, 2], [3, 4]], {s, 8}),
     ?assertEqual(Array#array.element_len, 2).
 
-valid_null_count_on_new(_Config) ->
+valid_null_count_on_from_erlang(_Config) ->
     Array1 = array([[1], [2], [3]], {s, 8}),
     ?assertEqual(Array1#array.null_count, 0),
 
@@ -65,7 +65,7 @@ valid_null_count_on_new(_Config) ->
     Array5 = array([[1], undefined, [nil], [2], [3]], {s, 8}),
     ?assertEqual(Array5#array.null_count, 1).
 
-valid_validity_bitmap_on_new(_Config) ->
+valid_validity_bitmap_on_from_erlang(_Config) ->
     %% Does not allocate bitmap on no nulls
     Array1 = array([[1], [2], [3]], {s, 8}),
     ?assertEqual(Array1#array.validity_bitmap, undefined),
@@ -100,11 +100,11 @@ valid_validity_bitmap_on_new(_Config) ->
         )
     ).
 
-valid_offsets_on_new(_Config) ->
+valid_offsets_on_from_erlang(_Config) ->
     Array = array([[1, 2, 3]], {s, 8}),
     ?assertEqual(Array#array.offsets, undefined).
 
-valid_data_on_new(_Config) ->
+valid_data_on_from_erlang(_Config) ->
     %% Works without any nulls
     Array1 = array([[1, 2], [3, 4]], {s, 8}),
     Data1 = primitive([1, 2, 3, 4]),
@@ -123,7 +123,7 @@ valid_data_on_new(_Config) ->
     Data4 = primitive([1, 2, undefined, undefined, 3, 4]),
     ?assertEqual(Array4#array.data, Data4).
 
-valid_nested_data_on_new(_Config) ->
+valid_nested_data_on_from_erlang(_Config) ->
     %% Works without any nulls
     Array1 = array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], {fixed_list, s8, 2}),
     Data1 = array([[1, 2], [3, 4], [5, 6], [7, 8]], s8),
@@ -179,7 +179,7 @@ crashes_on_invalid_nesting(_Config) ->
 %% Array Behaviour Adherence Tests %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-new_callback(_Config) ->
+from_erlang_callback(_Config) ->
     Array = array([[1, 2], [3, 4]], {s, 8}),
     Callback = array([[1, 2], [3, 4]], #{type => {s, 8}}),
     ?assertEqual(Callback, Array),
@@ -191,7 +191,7 @@ new_callback(_Config) ->
 %%%%%%%%%%%
 
 array(Values, Type) ->
-    serde_arrow_fixed_list_array:new(Values, Type).
+    serde_arrow_fixed_list_array:from_erlang(Values, Type).
 
 primitive(Values) ->
-    serde_arrow_fixed_primitive_array:new(Values, {s, 8}).
+    serde_arrow_fixed_primitive_array:from_erlang(Values, {s, 8}).

--- a/test/serde_arrow_fixed_primitive_array_SUITE.erl
+++ b/test/serde_arrow_fixed_primitive_array_SUITE.erl
@@ -9,82 +9,82 @@
 
 all() ->
     [
-        valid_layout_on_new,
-        valid_type_on_new,
-        valid_len_on_new,
-        valid_element_len_on_new,
-        valid_null_count_on_new,
-        valid_validity_bitmap_on_new,
-        valid_offsets_on_new,
-        valid_data_on_new,
+        valid_layout_on_from_erlang,
+        valid_type_on_from_erlang,
+        valid_len_on_from_erlang,
+        valid_element_len_on_from_erlang,
+        valid_null_count_on_from_erlang,
+        valid_validity_bitmap_on_from_erlang,
+        valid_offsets_on_from_erlang,
+        valid_data_on_from_erlang,
 
         %% Behaviour Adherence
-        new_callback
+        from_erlang_callback
     ].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Fixed Primitive Array Creation Tests %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-valid_layout_on_new(_Config) ->
-    Array = serde_arrow_fixed_primitive_array:new([1, 2, 3], {s, 8}),
+valid_layout_on_from_erlang(_Config) ->
+    Array = serde_arrow_fixed_primitive_array:from_erlang([1, 2, 3], {s, 8}),
     ?assertEqual(Array#array.layout, fixed_primitive).
 
-valid_type_on_new(_Config) ->
-    Array1 = serde_arrow_fixed_primitive_array:new([1, 2, 3], {s, 8}),
+valid_type_on_from_erlang(_Config) ->
+    Array1 = serde_arrow_fixed_primitive_array:from_erlang([1, 2, 3], {s, 8}),
     ?assertEqual(Array1#array.type, {s, 8}),
 
     %% Normalizes the type
-    Array2 = serde_arrow_fixed_primitive_array:new([1, 2, 3], s8),
+    Array2 = serde_arrow_fixed_primitive_array:from_erlang([1, 2, 3], s8),
     ?assertEqual(Array2#array.type, {s, 8}).
 
-valid_len_on_new(_Config) ->
-    Array = serde_arrow_fixed_primitive_array:new([1, 2, 3], {s, 8}),
+valid_len_on_from_erlang(_Config) ->
+    Array = serde_arrow_fixed_primitive_array:from_erlang([1, 2, 3], {s, 8}),
     ?assertEqual(Array#array.len, 3).
 
-valid_element_len_on_new(_Config) ->
-    Array = serde_arrow_fixed_primitive_array:new([1, 2, 3], {s, 8}),
+valid_element_len_on_from_erlang(_Config) ->
+    Array = serde_arrow_fixed_primitive_array:from_erlang([1, 2, 3], {s, 8}),
     ?assertEqual(Array#array.element_len, undefined).
 
-valid_null_count_on_new(_Config) ->
-    Array1 = serde_arrow_fixed_primitive_array:new([1, 2, 3], {s, 8}),
+valid_null_count_on_from_erlang(_Config) ->
+    Array1 = serde_arrow_fixed_primitive_array:from_erlang([1, 2, 3], {s, 8}),
     ?assertEqual(Array1#array.null_count, 0),
 
-    Array2 = serde_arrow_fixed_primitive_array:new([1, undefined, 2, 3], {s, 8}),
+    Array2 = serde_arrow_fixed_primitive_array:from_erlang([1, undefined, 2, 3], {s, 8}),
     ?assertEqual(Array2#array.null_count, 1),
 
-    Array3 = serde_arrow_fixed_primitive_array:new([1, nil, 2, 3], {s, 8}),
+    Array3 = serde_arrow_fixed_primitive_array:from_erlang([1, nil, 2, 3], {s, 8}),
     ?assertEqual(Array3#array.null_count, 1),
 
-    Array4 = serde_arrow_fixed_primitive_array:new([1, undefined, nil, 2, 3], {s, 8}),
+    Array4 = serde_arrow_fixed_primitive_array:from_erlang([1, undefined, nil, 2, 3], {s, 8}),
     ?assertEqual(Array4#array.null_count, 2).
 
-valid_validity_bitmap_on_new(_Config) ->
+valid_validity_bitmap_on_from_erlang(_Config) ->
     %% Does not allocate bitmap on no nulls
-    Array1 = serde_arrow_fixed_primitive_array:new([1, 2, 3], {s, 8}),
+    Array1 = serde_arrow_fixed_primitive_array:from_erlang([1, 2, 3], {s, 8}),
     ?assertEqual(Array1#array.validity_bitmap, undefined),
 
     %% Respects both Erlang's and Elixir's conventions
-    Array2 = serde_arrow_fixed_primitive_array:new([1, undefined, 2, 3], {s, 8}),
+    Array2 = serde_arrow_fixed_primitive_array:from_erlang([1, undefined, 2, 3], {s, 8}),
     ?assertEqual(
         Array2#array.validity_bitmap,
         serde_arrow_test_utils:byte_buffer(<<0:1, 0:1, 0:1, 0:1, 1:1, 1:1, 0:1, 1:1>>)
     ),
 
-    Array3 = serde_arrow_fixed_primitive_array:new([1, nil, 2, 3], {s, 8}),
+    Array3 = serde_arrow_fixed_primitive_array:from_erlang([1, nil, 2, 3], {s, 8}),
     ?assertEqual(
         Array3#array.validity_bitmap,
         serde_arrow_test_utils:byte_buffer(<<0:1, 0:1, 0:1, 0:1, 1:1, 1:1, 0:1, 1:1>>)
     ),
 
-    Array4 = serde_arrow_fixed_primitive_array:new([1, undefined, nil, 2], {s, 8}),
+    Array4 = serde_arrow_fixed_primitive_array:from_erlang([1, undefined, nil, 2], {s, 8}),
     ?assertEqual(
         Array4#array.validity_bitmap,
         serde_arrow_test_utils:byte_buffer(<<0:1, 0:1, 0:1, 0:1, 1:1, 0:1, 0:1, 1:1>>)
     ),
 
     %% Correctly validates on input greater than 8 elements
-    Array5 = serde_arrow_fixed_primitive_array:new(
+    Array5 = serde_arrow_fixed_primitive_array:from_erlang(
         [1, 2, undefined, 4, 5, 6, 7, 8, nil, 10], {s, 8}
     ),
     ?assertEqual(
@@ -94,26 +94,26 @@ valid_validity_bitmap_on_new(_Config) ->
         )
     ).
 
-valid_offsets_on_new(_Config) ->
-    Array = serde_arrow_fixed_primitive_array:new([1, 2, 3], {s, 8}),
+valid_offsets_on_from_erlang(_Config) ->
+    Array = serde_arrow_fixed_primitive_array:from_erlang([1, 2, 3], {s, 8}),
     ?assertEqual(Array#array.offsets, undefined).
 
-valid_data_on_new(_Config) ->
+valid_data_on_from_erlang(_Config) ->
     %% Works without any nulls
-    Array1 = serde_arrow_fixed_primitive_array:new([1, 2, 3], {s, 8}),
+    Array1 = serde_arrow_fixed_primitive_array:from_erlang([1, 2, 3], {s, 8}),
     Data1 = [1, 2, 3],
     ?assertEqual(Array1#array.data#buffer.data, Data1),
 
     %% Works with undefined and nil
-    Array2 = serde_arrow_fixed_primitive_array:new([1, 2, undefined, 3], {s, 8}),
+    Array2 = serde_arrow_fixed_primitive_array:from_erlang([1, 2, undefined, 3], {s, 8}),
     Data2 = [1, 2, undefined, 3],
     ?assertEqual(Array2#array.data#buffer.data, Data2),
 
-    Array3 = serde_arrow_fixed_primitive_array:new([1, 2, nil, 3], {s, 8}),
+    Array3 = serde_arrow_fixed_primitive_array:from_erlang([1, 2, nil, 3], {s, 8}),
     Data3 = [1, 2, nil, 3],
     ?assertEqual(Array3#array.data#buffer.data, Data3),
 
-    Array4 = serde_arrow_fixed_primitive_array:new([1, 2, undefined, nil, 3], {s, 8}),
+    Array4 = serde_arrow_fixed_primitive_array:from_erlang([1, 2, undefined, nil, 3], {s, 8}),
     Data4 = [1, 2, undefined, nil, 3],
     ?assertEqual(Array4#array.data#buffer.data, Data4).
 
@@ -121,9 +121,9 @@ valid_data_on_new(_Config) ->
 %% Array Behaviour Adherence Tests %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-new_callback(_Config) ->
-    Array = serde_arrow_fixed_primitive_array:new([1, 2], {s, 8}),
-    Callback = serde_arrow_fixed_primitive_array:new([1, 2], #{type => {s, 8}}),
+from_erlang_callback(_Config) ->
+    Array = serde_arrow_fixed_primitive_array:from_erlang([1, 2], {s, 8}),
+    Callback = serde_arrow_fixed_primitive_array:from_erlang([1, 2], #{type => {s, 8}}),
     ?assertEqual(Callback, Array),
 
-    ?assertError(badarg, serde_arrow_fixed_primitive_array:new([1, 2], #{foo => bar})).
+    ?assertError(badarg, serde_arrow_fixed_primitive_array:from_erlang([1, 2], #{foo => bar})).

--- a/test/serde_arrow_variable_binary_array_SUITE.erl
+++ b/test/serde_arrow_variable_binary_array_SUITE.erl
@@ -9,77 +9,77 @@
 
 all() ->
     [
-        valid_layout_on_new,
-        valid_type_on_new,
-        valid_len_on_new,
-        valid_element_len_on_new,
-        valid_null_count_on_new,
-        valid_validity_bitmap_on_new,
-        valid_offsets_on_new,
-        valid_data_on_new,
+        valid_layout_on_from_erlang,
+        valid_type_on_from_erlang,
+        valid_len_on_from_erlang,
+        valid_element_len_on_from_erlang,
+        valid_null_count_on_from_erlang,
+        valid_validity_bitmap_on_from_erlang,
+        valid_offsets_on_from_erlang,
+        valid_data_on_from_erlang,
 
         %% Behaviour Adherence
-        new_callback
+        from_erlang_callback
     ].
 
-valid_layout_on_new(_Config) ->
-    Array = serde_arrow_variable_binary_array:new([<<1>>, <<2>>, <<3, 4>>]),
+valid_layout_on_from_erlang(_Config) ->
+    Array = serde_arrow_variable_binary_array:from_erlang([<<1>>, <<2>>, <<3, 4>>]),
     ?assertEqual(Array#array.layout, variable_binary).
 
-valid_type_on_new(_Config) ->
-    Array = serde_arrow_variable_binary_array:new([<<1>>, <<2>>, <<3>>]),
+valid_type_on_from_erlang(_Config) ->
+    Array = serde_arrow_variable_binary_array:from_erlang([<<1>>, <<2>>, <<3>>]),
     ?assertEqual(Array#array.type, {bin, undefined}).
 
-valid_len_on_new(_Config) ->
-    Array1 = serde_arrow_variable_binary_array:new([<<1, 2>>, <<3>>]),
+valid_len_on_from_erlang(_Config) ->
+    Array1 = serde_arrow_variable_binary_array:from_erlang([<<1, 2>>, <<3>>]),
     ?assertEqual(Array1#array.len, 2),
 
-    Array2 = serde_arrow_variable_binary_array:new([<<1, 2>>, undefined, <<3>>]),
+    Array2 = serde_arrow_variable_binary_array:from_erlang([<<1, 2>>, undefined, <<3>>]),
     ?assertEqual(Array2#array.len, 3).
 
-valid_element_len_on_new(_Config) ->
-    Array = serde_arrow_variable_binary_array:new([<<1>>, <<2>>, <<3>>]),
+valid_element_len_on_from_erlang(_Config) ->
+    Array = serde_arrow_variable_binary_array:from_erlang([<<1>>, <<2>>, <<3>>]),
     ?assertEqual(Array#array.element_len, undefined).
 
-valid_null_count_on_new(_Config) ->
-    Array1 = serde_arrow_variable_binary_array:new([<<1, 2>>, <<3>>]),
+valid_null_count_on_from_erlang(_Config) ->
+    Array1 = serde_arrow_variable_binary_array:from_erlang([<<1, 2>>, <<3>>]),
     ?assertEqual(Array1#array.null_count, 0),
 
-    Array2 = serde_arrow_variable_binary_array:new([<<1>>, undefined, <<2, 3>>]),
+    Array2 = serde_arrow_variable_binary_array:from_erlang([<<1>>, undefined, <<2, 3>>]),
     ?assertEqual(Array2#array.null_count, 1),
 
-    Array3 = serde_arrow_variable_binary_array:new([<<1>>, nil, <<2, 3>>]),
+    Array3 = serde_arrow_variable_binary_array:from_erlang([<<1>>, nil, <<2, 3>>]),
     ?assertEqual(Array3#array.null_count, 1),
 
-    Array4 = serde_arrow_variable_binary_array:new([<<1>>, undefined, nil, <<2, 3>>]),
+    Array4 = serde_arrow_variable_binary_array:from_erlang([<<1>>, undefined, nil, <<2, 3>>]),
     ?assertEqual(Array4#array.null_count, 2).
 
-valid_validity_bitmap_on_new(_Config) ->
+valid_validity_bitmap_on_from_erlang(_Config) ->
     %% Does not allocate bitmap on no nulls
-    Array1 = serde_arrow_variable_binary_array:new([<<1, 2>>, <<3>>]),
+    Array1 = serde_arrow_variable_binary_array:from_erlang([<<1, 2>>, <<3>>]),
     ?assertEqual(Array1#array.validity_bitmap, undefined),
 
     %% Respects both Erlang's and Elixir's conventions
-    Array2 = serde_arrow_variable_binary_array:new([<<1>>, undefined, <<2, 3>>]),
+    Array2 = serde_arrow_variable_binary_array:from_erlang([<<1>>, undefined, <<2, 3>>]),
     ?assertEqual(
         Array2#array.validity_bitmap,
         serde_arrow_test_utils:byte_buffer(<<0:1, 0:1, 0:1, 0:1, 0:1, 1:1, 0:1, 1:1>>)
     ),
 
-    Array3 = serde_arrow_variable_binary_array:new([<<1>>, nil, <<2, 3>>]),
+    Array3 = serde_arrow_variable_binary_array:from_erlang([<<1>>, nil, <<2, 3>>]),
     ?assertEqual(
         Array3#array.validity_bitmap,
         serde_arrow_test_utils:byte_buffer(<<0:1, 0:1, 0:1, 0:1, 0:1, 1:1, 0:1, 1:1>>)
     ),
 
-    Array4 = serde_arrow_variable_binary_array:new([<<1>>, undefined, nil, <<2, 3>>]),
+    Array4 = serde_arrow_variable_binary_array:from_erlang([<<1>>, undefined, nil, <<2, 3>>]),
     ?assertEqual(
         Array4#array.validity_bitmap,
         serde_arrow_test_utils:byte_buffer(<<0:1, 0:1, 0:1, 0:1, 1:1, 0:1, 0:1, 1:1>>)
     ),
 
     %% Correctly validates on input greater than 8 elements
-    Array5 = serde_arrow_variable_binary_array:new([
+    Array5 = serde_arrow_variable_binary_array:from_erlang([
         <<1>>, <<2>>, undefined, <<4>>, <<5>>, <<6>>, <<7>>, <<8>>, nil, <<10, 11, 12>>
     ]),
     ?assertEqual(
@@ -89,17 +89,19 @@ valid_validity_bitmap_on_new(_Config) ->
         )
     ).
 
-valid_offsets_on_new(_Config) ->
-    Array = serde_arrow_variable_binary_array:new([<<1, 2>>, <<3>>, undefined, <<4>>, nil, <<5>>]),
+valid_offsets_on_from_erlang(_Config) ->
+    Array = serde_arrow_variable_binary_array:from_erlang([
+        <<1, 2>>, <<3>>, undefined, <<4>>, nil, <<5>>
+    ]),
     Buffer = serde_arrow_buffer:from_erlang([0, 2, 3, 3, 4, 4, 5], {s, 32}),
     ?assertEqual(Array#array.offsets, Buffer).
 
-valid_data_on_new(_Config) ->
-    Array1 = serde_arrow_variable_binary_array:new([<<1, 2>>, <<3>>, <<4>>, <<5>>]),
+valid_data_on_from_erlang(_Config) ->
+    Array1 = serde_arrow_variable_binary_array:from_erlang([<<1, 2>>, <<3>>, <<4>>, <<5>>]),
     Buffer1 = binary_buffer(<<1, 2, 3, 4, 5>>),
     ?assertEqual(Array1#array.data, Buffer1),
 
-    Array2 = serde_arrow_variable_binary_array:new([
+    Array2 = serde_arrow_variable_binary_array:from_erlang([
         <<1, 2>>, <<3, 4, 5>>, undefined, <<6, 7, 8>>, nil, <<9, 10>>
     ]),
     Buffer2 = binary_buffer(<<1, 2, 3, 4, 5, 6, 7, 8, 9, 10>>),
@@ -109,9 +111,9 @@ valid_data_on_new(_Config) ->
 %% Array Behaviour Adherence Tests %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-new_callback(_Config) ->
-    Array = serde_arrow_variable_binary_array:new([<<1>>, <<2>>]),
-    Callback = serde_arrow_variable_binary_array:new([<<1>>, <<2>>], #{}),
+from_erlang_callback(_Config) ->
+    Array = serde_arrow_variable_binary_array:from_erlang([<<1>>, <<2>>]),
+    Callback = serde_arrow_variable_binary_array:from_erlang([<<1>>, <<2>>], #{}),
     ?assertEqual(Callback, Array).
 
 %%%%%%%%%%%

--- a/test/serde_arrow_variable_list_array_SUITE.erl
+++ b/test/serde_arrow_variable_list_array_SUITE.erl
@@ -9,26 +9,26 @@
 
 all() ->
     [
-        valid_layout_on_new,
-        valid_type_on_new,
-        valid_len_on_new,
-        valid_element_len_on_new,
-        valid_null_count_on_new,
-        valid_validity_bitmap_on_new,
-        valid_offsets_on_new,
-        valid_data_on_new,
-        valid_nested_data_on_new,
+        valid_layout_on_from_erlang,
+        valid_type_on_from_erlang,
+        valid_len_on_from_erlang,
+        valid_element_len_on_from_erlang,
+        valid_null_count_on_from_erlang,
+        valid_validity_bitmap_on_from_erlang,
+        valid_offsets_on_from_erlang,
+        valid_data_on_from_erlang,
+        valid_nested_data_on_from_erlang,
         crashes_on_invalid_data,
 
         %% Behaviour Adherence
-        new_callback
+        from_erlang_callback
     ].
 
-valid_layout_on_new(_Config) ->
+valid_layout_on_from_erlang(_Config) ->
     Array = array([[1, 2, 3]], {s, 8}),
     ?assertEqual(Array#array.layout, variable_list).
 
-valid_type_on_new(_Config) ->
+valid_type_on_from_erlang(_Config) ->
     Array1 = array([[1, 2, 3]], {s, 8}),
     ?assertEqual(Array1#array.type, {s, 8}),
 
@@ -36,15 +36,15 @@ valid_type_on_new(_Config) ->
     Array2 = array([[1, 2, 3]], s8),
     ?assertEqual(Array2#array.type, {s, 8}).
 
-valid_len_on_new(_Config) ->
+valid_len_on_from_erlang(_Config) ->
     Array = array([[1], [2], [3]], {s, 8}),
     ?assertEqual(Array#array.len, 3).
 
-valid_element_len_on_new(_Config) ->
+valid_element_len_on_from_erlang(_Config) ->
     Array = array([[1, 2], [3, 4]], {s, 8}),
     ?assertEqual(Array#array.element_len, undefined).
 
-valid_null_count_on_new(_Config) ->
+valid_null_count_on_from_erlang(_Config) ->
     Array1 = array([[1], [2], [3]], {s, 8}),
     ?assertEqual(Array1#array.null_count, 0),
 
@@ -60,7 +60,7 @@ valid_null_count_on_new(_Config) ->
     Array5 = array([[1], undefined, [nil], [2], [3]], {s, 8}),
     ?assertEqual(Array5#array.null_count, 1).
 
-valid_validity_bitmap_on_new(_Config) ->
+valid_validity_bitmap_on_from_erlang(_Config) ->
     %% Does not allocate bitmap on no nulls
     Array1 = array([[1], [2], [3]], {s, 8}),
     ?assertEqual(Array1#array.validity_bitmap, undefined),
@@ -95,7 +95,7 @@ valid_validity_bitmap_on_new(_Config) ->
         )
     ).
 
-valid_offsets_on_new(_Config) ->
+valid_offsets_on_from_erlang(_Config) ->
     Array1 = array([[1, 2], [3], undefined, [4], nil, [5]], s8),
     Buffer1 = serde_arrow_buffer:from_erlang([0, 2, 3, 3, 4, 4, 5], {s, 32}),
     ?assertEqual(Array1#array.offsets, Buffer1),
@@ -121,7 +121,7 @@ valid_offsets_on_new(_Config) ->
     Buffer4 = serde_arrow_buffer:from_erlang([0, 2, 4, 6], {s, 32}),
     ?assertEqual(Array4#array.offsets, Buffer4).
 
-valid_data_on_new(_Config) ->
+valid_data_on_from_erlang(_Config) ->
     %% Works without any nulls
     Array1 = array([[1, 2], [3, 4, 5]], {s, 8}),
     Data1 = primitive([1, 2, 3, 4, 5]),
@@ -150,12 +150,12 @@ valid_data_on_new(_Config) ->
         [[<<"one">>, <<"two">>, <<"three">>], [<<"quatre">>, <<"cinq">>], [<<"ആറ്">>]],
         {bin, undefined}
     ),
-    Data6 = serde_arrow_variable_binary_array:new([
+    Data6 = serde_arrow_variable_binary_array:from_erlang([
         <<"one">>, <<"two">>, <<"three">>, <<"quatre">>, <<"cinq">>, <<"ആറ്">>
     ]),
     ?assertEqual(Array6#array.data, Data6).
 
-valid_nested_data_on_new(_Config) ->
+valid_nested_data_on_from_erlang(_Config) ->
     %% Works without any nulls
     Array1 = array([[[1, 2], [3, 4, 5]], [[6], [7, 8, 9]]], {variable_list, s8, undefined}),
     Data1 = array([[1, 2], [3, 4, 5], [6], [7, 8, 9]], s8),
@@ -188,7 +188,7 @@ valid_nested_data_on_new(_Config) ->
 
     %% Nesting of other layouts
     Array6 = array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], {fixed_list, s8, 2}),
-    Data6 = serde_arrow_fixed_list_array:new([[1, 2], [3, 4], [5, 6], [7, 8]], s8),
+    Data6 = serde_arrow_fixed_list_array:from_erlang([[1, 2], [3, 4], [5, 6], [7, 8]], s8),
     ?assertEqual(Array6#array.data, Data6).
 
 crashes_on_invalid_data(_Config) ->
@@ -211,7 +211,7 @@ crashes_on_invalid_data(_Config) ->
 %% Array Behaviour Adherence Tests %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-new_callback(_Config) ->
+from_erlang_callback(_Config) ->
     Array = array([[1, 2], [3, 4]], {s, 8}),
     Callback = array([[1, 2], [3, 4]], #{type => {s, 8}}),
     ?assertEqual(Callback, Array),
@@ -223,7 +223,7 @@ new_callback(_Config) ->
 %%%%%%%%%%%
 
 array(Values, Type) ->
-    serde_arrow_variable_list_array:new(Values, Type).
+    serde_arrow_variable_list_array:from_erlang(Values, Type).
 
 primitive(Values) ->
-    serde_arrow_fixed_primitive_array:new(Values, {s, 8}).
+    serde_arrow_fixed_primitive_array:from_erlang(Values, {s, 8}).


### PR DESCRIPTION
This commit renames array:new, and its callbacks, and its compliant
modules' functions to from_erlang. This is necessary to distinguish
between creating an array from erlang and from arrow. This is also sets
the precedent for conversions to erlang and to arrow. This change is
similar to the change done to buffer.
