### PR TITLE
Support modelling Schema Encapsulated Messages

### DIFF
--- a/src/serde_arrow_ipc_field.erl
+++ b/src/serde_arrow_ipc_field.erl
@@ -1,0 +1,24 @@
+-module(serde_arrow_ipc_field).
+-export([from_erlang/1, from_erlang/2]).
+
+-include("serde_arrow_ipc_schema.hrl").
+
+-spec from_erlang(Type :: serde_arrow_type:arrow_longhand_type()) -> Field :: #field{}.
+from_erlang(Type) ->
+    from_erlang(Type, undefined).
+
+-spec from_erlang(Type :: serdelayoutow_type:arrow_longhand_type(), Name :: string() | undefined) ->
+    Field :: #field{}.
+from_erlang(Type, Name) when tuple_size(Type) =:= 2 ->
+    #field{name = Name, type = layout(Type)};
+from_erlang({_, NestedType, _} = Type, Name) ->
+    #field{name = Name, type = layout(Type), children = [from_erlang(NestedType)]}.
+
+-spec layout(Type :: serde_arrow_type:arrow_longhand_type()) ->
+    Layout :: serde_arrow_array:layout().
+layout({_, Size}) when is_integer(Size) ->
+    fixed_primitive;
+layout({_, undefined}) ->
+    variable_binary;
+layout({Layout, _, _}) ->
+    Layout.

--- a/src/serde_arrow_ipc_field.erl
+++ b/src/serde_arrow_ipc_field.erl
@@ -1,12 +1,51 @@
+%% @doc Provides a record and functions to deal with individual fields in
+%% a Schema
+%%
+%% A Field[1] represents a single column in a table (which is represented by a
+%% Schema[2]). This module provides a record and a function to manage all the
+%% metadata required to represent a column. Metadata such as:
+%%
+%% <ol>
+%%  <li>
+%%      `name': The Name of the column. This can either be a string or null.
+%%  </li>
+%%  <li>
+%%      `nullable': A boolean representing whether a column can have null values.
+%%      Generally true.
+%%  </li>
+%%  <li>
+%%      `type': The Layout of the column
+%%  </li>
+%%  <li>
+%%      `dictionary': A boolean representing if the column is dictionary encoded
+%%  </li>
+%%  <li>
+%%      `children': The child fields of a nested datatype
+%%  </li>
+%%  <li>
+%%      `custom_metadata': A list of custom metadata in key-value format
+%%  </li>
+%% </ol>
+%%
+%% Currently, dictionary encoding and custom metadata are not supported, but
+%% they have been added for forwards comapatibility.
+%%
+%% [1]: [https://github.com/apache/arrow/blob/3456131ab7350bee5d9569ffd63d3f0ee713991c/format/Schema.fbs#L469-L492]
+%%
+%% [2]: [https://github.com/apache/arrow/blob/3456131ab7350bee5d9569ffd63d3f0ee713991c/format/Schema.fbs#L514-L530]
+%% @end
 -module(serde_arrow_ipc_field).
 -export([from_erlang/1, from_erlang/2]).
 
 -include("serde_arrow_ipc_schema.hrl").
 
+%% @doc Creates a field given the type of the column. Assigns the name as
+%% `undefined'.
 -spec from_erlang(Type :: serde_arrow_type:arrow_longhand_type()) -> Field :: #field{}.
 from_erlang(Type) ->
     from_erlang(Type, undefined).
 
+%% @doc Creates a field given the type and name of the column.
 -spec from_erlang(Type :: serdelayoutow_type:arrow_longhand_type(), Name :: string() | undefined) ->
     Field :: #field{}.
 from_erlang(Type, Name) when tuple_size(Type) =:= 2 ->

--- a/src/serde_arrow_ipc_field.hrl
+++ b/src/serde_arrow_ipc_field.hrl
@@ -1,0 +1,8 @@
+-record(field, {
+    name :: string() | undefined,
+    nullable = true :: boolean(),
+    type :: serde_arrow_array:layout(),
+    dictionary = undefined,
+    children = [] :: [#field{}],
+    custom_metadata = [] :: [serde_arrow_ipc_message:key_value()]
+}).

--- a/src/serde_arrow_ipc_message.erl
+++ b/src/serde_arrow_ipc_message.erl
@@ -1,3 +1,37 @@
+%% @doc Provides a record and functions to deal with the Encapsulated Message
+%% Format.
+%%
+%% A Message is a serialized form of a Schema[1] or a RecordBatch[2] (which may
+%% be required to read a serialized array) along with some metadata. This module
+%% provides a record and a function to manage all the metadata required to
+%% represent a message. Metadata such as:
+%%
+%% <ol>
+%%  <li>
+%%      `version': The Apache Arrow Format Version. One of v1..v5. Defaults to v5.
+%%  </li>
+%%  <li>
+%%      `header': The metadata of the Schema or RecordBatch
+%%  </li>
+%%  <li>
+%%      `body_length': The length of the body in bytes
+%%  </li>
+%%  <li>
+%%      `custom_metadata': A list of custom metadata in key-value format
+%%  </li>
+%%  <li>
+%%      `body': The actual body. Can be undefined (in the case of Schema) or a
+%%      binary (in the case of Record Batch).
+%%  </li>
+%% </ol>
+%%
+%% Currently, changing the version and custom metadata are not supported, but
+%% they have been added for forwards comapatibility.
+%%
+%% [1]: [https://arrow.apache.org/docs/format/Columnar.html#schema-message]
+%%
+%% [2]: [https://arrow.apache.org/docs/format/Columnar.html#recordbatch-message]
+%% @end
 -module(serde_arrow_ipc_message).
 -export([from_erlang/1]).
 -export_type([metadata_version/0, key_value/0]).
@@ -6,11 +40,11 @@
 
 -type metadata_version() :: v1 | v2 | v3 | v4 | v5.
 %% The Arrow version. See the definition for more info:
-%% https://github.com/apache/arrow/blob/3456131ab7350bee5d9569ffd63d3f0ee713991c/format/Schema.fbs#L28-L49
+%% [https://github.com/apache/arrow/blob/3456131ab7350bee5d9569ffd63d3f0ee713991c/format/Schema.fbs#L28-L49]
 
 -type key_value() :: #{key => string(), value => string()}.
 %% Key-Value structure for custom metadata. See the definition for more info:
-%% https://github.com/apache/arrow/blob/3456131ab7350bee5d9569ffd63d3f0ee713991c/format/Schema.fbs#L432-L439
+%% [https://github.com/apache/arrow/blob/3456131ab7350bee5d9569ffd63d3f0ee713991c/format/Schema.fbs#L432-L439]
 
 -spec from_erlang(Header :: #schema{}) -> Message :: #message{}.
 from_erlang(Header) ->

--- a/src/serde_arrow_ipc_message.erl
+++ b/src/serde_arrow_ipc_message.erl
@@ -1,0 +1,17 @@
+-module(serde_arrow_ipc_message).
+-export([from_erlang/1]).
+-export_type([metadata_version/0, key_value/0]).
+
+-include("serde_arrow_ipc_message.hrl").
+
+-type metadata_version() :: v1 | v2 | v3 | v4 | v5.
+%% The Arrow version. See the definition for more info:
+%% https://github.com/apache/arrow/blob/3456131ab7350bee5d9569ffd63d3f0ee713991c/format/Schema.fbs#L28-L49
+
+-type key_value() :: #{key => string(), value => string()}.
+%% Key-Value structure for custom metadata. See the definition for more info:
+%% https://github.com/apache/arrow/blob/3456131ab7350bee5d9569ffd63d3f0ee713991c/format/Schema.fbs#L432-L439
+
+-spec from_erlang(Header :: #schema{}) -> Message :: #message{}.
+from_erlang(Header) ->
+    #message{header = Header, body_length = 0}.

--- a/src/serde_arrow_ipc_message.hrl
+++ b/src/serde_arrow_ipc_message.hrl
@@ -1,0 +1,12 @@
+-include("serde_arrow_ipc_schema.hrl").
+
+-record(message, {
+    version = v5 :: serde_arrow_ipc_message:metadata_version(),
+    header :: #schema{},
+    body_length :: non_neg_integer(),
+    custom_metadata = [] :: [serde_arrow_ipc_message:key_value()],
+
+    %% This field is unique to serde_arrow.
+    %% The rest are from the flatbuffers definitions.
+    body :: binary() | undefined
+}).

--- a/src/serde_arrow_ipc_schema.erl
+++ b/src/serde_arrow_ipc_schema.erl
@@ -1,3 +1,40 @@
+%% @doc Provides a record and functions to deal with Schemas
+%%
+%% A Schema[1] represents a table, or a list of arrays of equal length. This
+%% module provides a record and a function to manage all the metadata required
+%% to represent a schema. Metadata such as:
+%%
+%% <ol>
+%%  <li>
+%%      `endianness': The Endianness of the table. One of `little' or `big'.
+%%      Defaults to `little'.
+%%  </li>
+%%  <li>
+%%      `fields': The list of fields[2] in a table.
+%%  </li>
+%%  <li>
+%%      `type': The Layout of the column
+%%  </li>
+%%  <li>
+%%      `custom_metadata': A list of custom metadata in key-value format
+%%  </li>
+%%  <li>
+%%      `features': Any features used by the table which may not be present in
+%%      other implementations of Arrow.
+%%  </li>
+%% </ol>
+%%
+%% Currently, big endianness, custom metadata and features are not supported,
+%% but they have been added for forwards comapatibility.
+%%
+%% You can find Schemas in the Arrow spec here[3].
+%%
+%% [1]: [https://github.com/apache/arrow/blob/3456131ab7350bee5d9569ffd63d3f0ee713991c/format/Schema.fbs#L514-L530]
+%%
+%% [2]: [https://github.com/apache/arrow/blob/3456131ab7350bee5d9569ffd63d3f0ee713991c/format/Schema.fbs#L469-L492]
+%%
+%% [3]: [https://arrow.apache.org/docs/format/Columnar.html#schema-message]
+%% @end
 -module(serde_arrow_ipc_schema).
 -export([from_erlang/1]).
 -export_type([endianness/0, feature/0]).
@@ -5,14 +42,14 @@
 -include("serde_arrow_ipc_schema.hrl").
 
 -type endianness() :: little | big.
-%% Endianness of the data
+%% Endianness of the data. Either `little' or `big'.
 
 -type feature() :: unused | dictionary_replacement | compressed_body.
 %% Features used in the data which may not be present in other implementations.
 %% See the definition:
-%%
-%% https://github.com/apache/arrow/blob/3456131ab7350bee5d9569ffd63d3f0ee713991c/format/Schema.fbs#L51-L78
+%% [https://github.com/apache/arrow/blob/3456131ab7350bee5d9569ffd63d3f0ee713991c/format/Schema.fbs#L51-L78]
 
+%% @doc Creates a Schema given an ordered list of fields.
 -spec from_erlang(Fields :: [#field{}]) -> Schema :: #schema{}.
 from_erlang(Fields) ->
     #schema{fields = Fields}.

--- a/src/serde_arrow_ipc_schema.erl
+++ b/src/serde_arrow_ipc_schema.erl
@@ -1,0 +1,18 @@
+-module(serde_arrow_ipc_schema).
+-export([from_erlang/1]).
+-export_type([endianness/0, feature/0]).
+
+-include("serde_arrow_ipc_schema.hrl").
+
+-type endianness() :: little | big.
+%% Endianness of the data
+
+-type feature() :: unused | dictionary_replacement | compressed_body.
+%% Features used in the data which may not be present in other implementations.
+%% See the definition:
+%%
+%% https://github.com/apache/arrow/blob/3456131ab7350bee5d9569ffd63d3f0ee713991c/format/Schema.fbs#L51-L78
+
+-spec from_erlang(Fields :: [#field{}]) -> Schema :: #schema{}.
+from_erlang(Fields) ->
+    #schema{fields = Fields}.

--- a/src/serde_arrow_ipc_schema.hrl
+++ b/src/serde_arrow_ipc_schema.hrl
@@ -1,0 +1,8 @@
+-include("serde_arrow_ipc_field.hrl").
+
+-record(schema, {
+    endianness = little :: serde_arrow_ipc_schema:endianness(),
+    fields = [#field{}],
+    custom_metadata = [] :: [serde_arrow_ipc_message:key_value()],
+    features = [unused] :: [serde_arrow_ipc_schema:feature()]
+}).

--- a/test/serde_arrow_ipc_field_SUITE.erl
+++ b/test/serde_arrow_ipc_field_SUITE.erl
@@ -1,0 +1,63 @@
+-module(serde_arrow_ipc_field_SUITE).
+
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-include("serde_arrow_ipc_field.hrl").
+
+all() ->
+    [
+        valid_name_on_from_erlang,
+        valid_nullable_on_from_erlang,
+        valid_type_on_from_erlang,
+        valid_dictionary_on_from_erlang,
+        valid_children_on_from_erlang,
+        valid_custom_metadata_on_from_erlang
+    ].
+
+valid_name_on_from_erlang(_Config) ->
+    Field1 = from_erlang({s, 8}, "id"),
+    ?assertEqual(Field1#field.name, "id"),
+
+    Field2 = from_erlang({s, 8}),
+    ?assertEqual(Field2#field.name, undefined).
+
+valid_nullable_on_from_erlang(_Config) ->
+    ?assertEqual((from_erlang({s, 8}))#field.nullable, true).
+
+valid_type_on_from_erlang(_Config) ->
+    ?assertEqual((from_erlang({s, 8}))#field.type, fixed_primitive),
+    ?assertEqual((from_erlang({bin, undefined}))#field.type, variable_binary),
+    ?assertEqual((from_erlang({fixed_list, {s, 8}, 4}))#field.type, fixed_list),
+    ?assertEqual((from_erlang({variable_list, {s, 8}, undefined}))#field.type, variable_list).
+
+valid_dictionary_on_from_erlang(_Config) ->
+    ?assertEqual((from_erlang({s, 8}))#field.dictionary, undefined).
+
+valid_children_on_from_erlang(_Config) ->
+    Field1 = from_erlang({s, 8}),
+    ?assertEqual(Field1#field.children, []),
+
+    Field2 = from_erlang({bin, undefined}),
+    ?assertEqual(Field2#field.children, []),
+
+    Field3 = from_erlang({fixed_list, {s, 8}, 4}),
+    ?assertEqual(Field3#field.children, [Field1]),
+
+    Field4 = from_erlang({variable_list, {s, 8}, undefined}),
+    ?assertEqual(Field4#field.children, [Field1]).
+
+valid_custom_metadata_on_from_erlang(_Config) ->
+    ?assertEqual((from_erlang({s, 8}))#field.custom_metadata, []).
+
+%%%%%%%%%%%
+%% Utils %%
+%%%%%%%%%%%
+
+from_erlang(X) ->
+    serde_arrow_ipc_field:from_erlang(X).
+
+from_erlang(X, Y) ->
+    serde_arrow_ipc_field:from_erlang(X, Y).

--- a/test/serde_arrow_ipc_message_SUITE.erl
+++ b/test/serde_arrow_ipc_message_SUITE.erl
@@ -1,0 +1,50 @@
+-module(serde_arrow_ipc_message_SUITE).
+
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-include("serde_arrow_ipc_message.hrl").
+
+-define(IDField, serde_arrow_ipc_field:from_erlang({s, 8}, "id")).
+-define(NameField, serde_arrow_ipc_field:from_erlang({bin, undefined}, "name")).
+-define(AgeField, serde_arrow_ipc_field:from_erlang({u, 8}, "age")).
+-define(AnnualMarksField,
+    serde_arrow_ipc_field:from_erlang({fixed_list, {u, 8}, 5}, "annual_marks")
+).
+-define(Schema, [?IDField, ?NameField, ?AgeField, ?AnnualMarksField]).
+
+all() ->
+    [
+        valid_version_on_from_erlang,
+        valid_header_on_from_erlang,
+        valid_body_length_on_from_erlang,
+        valid_custom_metadata_on_from_erlang,
+        valid_body_on_from_erlang
+    ].
+
+valid_version_on_from_erlang(_Config) ->
+    ?assertEqual((from_erlang(?Schema))#message.version, v5).
+
+valid_header_on_from_erlang(_Config) ->
+    ?assertEqual((from_erlang(?Schema))#message.header, ?Schema).
+
+valid_body_length_on_from_erlang(_Config) ->
+    ?assertEqual((from_erlang(?Schema))#message.body_length, 0).
+
+valid_custom_metadata_on_from_erlang(_Config) ->
+    ?assertEqual((from_erlang(?Schema))#message.custom_metadata, []).
+
+valid_body_on_from_erlang(_Config) ->
+    ?assertEqual((from_erlang(?Schema))#message.body, undefined).
+
+%%%%%%%%%%%
+%% Utils %%
+%%%%%%%%%%%
+
+from_erlang(X) ->
+    serde_arrow_ipc_message:from_erlang(X).
+
+from_erlang(X, Y) ->
+    serde_arrow_ipc_message:from_erlang(X, Y).

--- a/test/serde_arrow_ipc_schema_SUITE.erl
+++ b/test/serde_arrow_ipc_schema_SUITE.erl
@@ -1,0 +1,41 @@
+-module(serde_arrow_ipc_schema_SUITE).
+
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-include("serde_arrow_ipc_schema.hrl").
+
+-define(ID, serde_arrow_ipc_field:from_erlang({s, 8}, "id")).
+-define(Name, serde_arrow_ipc_field:from_erlang({bin, undefined}, "name")).
+-define(Age, serde_arrow_ipc_field:from_erlang({u, 8}, "age")).
+
+-define(Fields, [?ID, ?Name, ?Age]).
+
+all() ->
+    [
+        valid_endianness_on_from_erlang,
+        valid_fields_on_from_erlang,
+        valid_custom_metadata_on_from_erlang,
+        valid_features_on_from_erlang
+    ].
+
+valid_endianness_on_from_erlang(_Config) ->
+    ?assertEqual((from_erlang(?Fields))#schema.endianness, little).
+
+valid_fields_on_from_erlang(_Config) ->
+    ?assertEqual((from_erlang(?Fields))#schema.fields, ?Fields).
+
+valid_custom_metadata_on_from_erlang(_Config) ->
+    ?assertEqual((from_erlang(?Fields))#schema.custom_metadata, []).
+
+valid_features_on_from_erlang(_Config) ->
+    ?assertEqual((from_erlang(?Fields))#schema.features, [unused]).
+
+%%%%%%%%%%%
+%% Utils %%
+%%%%%%%%%%%
+
+from_erlang(X) ->
+    serde_arrow_ipc_schema:from_erlang(X).


### PR DESCRIPTION
This commit adds support for modelling (i.e. internally representing) IPC
encapsulated messages. Currently it only supports schema message types.
