### PR TITLE
Serialize arrays with array:to_arrow

### DIFF
--- a/test/serde_arrow_array_SUITE.erl
+++ b/test/serde_arrow_array_SUITE.erl
@@ -20,7 +20,10 @@ all() ->
         valid_null_count_on_access,
         valid_validity_bitmap_on_access,
         valid_offsets_on_access,
-        valid_data_on_access
+        valid_data_on_access,
+
+        %% serialization tests
+        valid_binary_on_to_arrow
     ].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -71,3 +74,64 @@ valid_offsets_on_access(_Config) ->
 valid_data_on_access(_Config) ->
     Array = serde_arrow_array:from_erlang(fixed_primitive, [1, 2, 3], {s, 8}),
     ?assertEqual(serde_arrow_array:data(Array), serde_arrow_buffer:from_erlang([1, 2, 3], {s, 8})).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Array Serialization Tests %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+valid_binary_on_to_arrow(_Config) ->
+    %% Primitive Fixed-Size Array
+    %% Also offsets is not allocated on no offsets
+
+    Array1 = serde_arrow_array:from_erlang(fixed_primitive, [1, 2, undefined, 3], {s, 8}),
+    Validity1 = pad(<<0:1, 0:1, 0:1, 0:1, 1:1, 0:1, 1:1, 1:1>>),
+    Data1 = pad(
+        <<1:8/integer-signed-little, 2:8/integer-signed-little, 0:8/integer-signed-little,
+            3:8/integer-signed-little>>
+    ),
+    Bin1 = <<Validity1/binary, Data1/binary>>,
+    ?assertEqual(serde_arrow_array:to_arrow(Array1), Bin1),
+
+    %% Variable-Size Binary
+    %% Also validity, offsets and data is correctly allocated
+    Array2 = serde_arrow_array:from_erlang(
+        variable_binary, [<<1>>, <<2, 3>>, undefined, <<4, 5, 6>>], {s, 8}
+    ),
+    Validity2 = Validity1,
+    Offsets2 = pad(
+        <<0:32/integer-signed-little, 1:32/integer-signed-little, 3:32/integer-signed-little,
+            3:32/integer-signed-little, 6:32/integer-signed-little>>
+    ),
+    Data2 = pad(<<1, 2, 3, 4, 5, 6>>),
+    Bin2 = <<Validity2/binary, Offsets2/binary, Data2/binary>>,
+    ?assertEqual(serde_arrow_array:to_arrow(Array2), Bin2),
+
+    %% Fixed-Sized List
+    %% Also validity not allocated on no nulls and recursive data is allocated.
+    Array3 = serde_arrow_array:from_erlang(
+        fixed_list, [[1, 2, undefined, 3], [4, 5, 6, 7]], {s, 8}
+    ),
+    Bin3 = serde_arrow_array:to_arrow(serde_arrow_array:data(Array3)),
+    ?assertEqual(serde_arrow_array:to_arrow(Array3), Bin3),
+
+    %% Variable-Size List
+    %% Also validity, offsets, and recursive data is correctly allocated
+    Array4 = serde_arrow_array:from_erlang(
+        variable_list, [[1, 2, undefined], [3, 4], undefined, [5]], {s, 8}
+    ),
+    Validity4 = Validity1,
+    Offsets4 = pad(
+        <<0:32/integer-signed-little, 3:32/integer-signed-little, 5:32/integer-signed-little,
+            5:32/integer-signed-little, 6:32/integer-signed-little>>
+    ),
+    Data4 = serde_arrow_array:to_arrow(serde_arrow_array:data(Array4)),
+    Bin4 = <<Validity4/binary, Offsets4/binary, Data4/binary>>,
+    ?assertEqual(serde_arrow_array:to_arrow(Array4), Bin4).
+
+%%%%%%%%%%%
+%% Utils %%
+%%%%%%%%%%%
+
+pad(X) ->
+    PadLen = 64 - byte_size(X) rem 64,
+    <<X/binary, (serde_arrow_test_utils:pad(PadLen))/binary>>.

--- a/test/serde_arrow_buffer_SUITE.erl
+++ b/test/serde_arrow_buffer_SUITE.erl
@@ -68,7 +68,7 @@ valid_regular_buffer_data_on_to_arrow(_Config) ->
     Bin1 = serde_arrow_buffer:to_arrow(serde_arrow_buffer:from_erlang([1, 2, 3], {s, 8})),
     Data1 =
         <<1/little-signed-integer, 2/little-signed-integer, 3/little-signed-integer,
-            (alternate_pad(61))/bitstring>>,
+            (pad(61))/bitstring>>,
     ?assertEqual(Bin1, Data1),
 
     %% Works with undefined and nil
@@ -77,7 +77,7 @@ valid_regular_buffer_data_on_to_arrow(_Config) ->
     ),
     Data2 =
         <<1/little-signed-integer, 2/little-signed-integer, 0, 3/little-signed-integer,
-            (alternate_pad(60))/bitstring>>,
+            (pad(60))/bitstring>>,
     ?assertEqual(Bin2, Data2),
 
     Bin3 = serde_arrow_buffer:to_arrow(serde_arrow_buffer:from_erlang([1, 2, nil, 3], {s, 8})),
@@ -89,13 +89,13 @@ valid_regular_buffer_data_on_to_arrow(_Config) ->
     ),
     Data4 =
         <<1/little-signed-integer, 2/little-signed-integer, 0, 0, 3/little-signed-integer,
-            (alternate_pad(59))/bitstring>>,
+            (pad(59))/bitstring>>,
     ?assertEqual(Bin4, Data4).
 
 valid_binary_buffer_data_on_to_arrow(_Config) ->
     Data =
         <<1/little-signed-integer, 2/little-signed-integer, 3/little-signed-integer,
-            (alternate_pad(61))/bitstring>>,
+            (pad(61))/bitstring>>,
 
     %% Works without any nulls
     Bin1 = serde_arrow_buffer:to_arrow(
@@ -138,5 +138,6 @@ to_erlang(_Config) ->
 
 %% We need to use a simpler alternate pad function to test the buffer's pad
 %% output.
-alternate_pad(ByteLen) ->
-    <<<<0>> || _X <- lists:seq(1, ByteLen)>>.
+
+pad(X) ->
+    serde_arrow_test_utils:pad(X).

--- a/test/serde_arrow_test_utils.erl
+++ b/test/serde_arrow_test_utils.erl
@@ -1,6 +1,10 @@
 -module(serde_arrow_test_utils).
--export([byte_buffer/1]).
+-export([byte_buffer/1, pad/1]).
 
 %% This function returns a buffer of type bin, given a binary as input
 byte_buffer(Binary) ->
     serde_arrow_buffer:from_erlang(Binary, {bin, undefined}).
+
+%% Returns a binary with 0 padded to a certain length.
+pad(ByteLen) ->
+    <<<<0>> || _X <- lists:seq(1, ByteLen)>>.


### PR DESCRIPTION
This commit adds support to serialize an Arrow Array to its binary form
consisting of just its validity, offsets, and data (i.e. all the buffers
in an array) concatenated together.
