### PR TITLE
Support writing incomplete Encapsulated Messages

### DIFF
--- a/src/serde_arrow_ipc_message.erl
+++ b/src/serde_arrow_ipc_message.erl
@@ -28,9 +28,16 @@
 %% Currently, changing the version and custom metadata are not supported, but
 %% they have been added for forwards comapatibility.
 %%
+%% This module also provides the `to_ipc/1' function which serializes the
+%% message into the Encapsulated Message Format[3]. However, this function gives
+%% <em>incomplete output</em> with invalid metadata, because of an unsatisfied
+%% dependency on flatbuffers, which is required for serializing the metadata.
+%%
 %% [1]: [https://arrow.apache.org/docs/format/Columnar.html#schema-message]
 %%
 %% [2]: [https://arrow.apache.org/docs/format/Columnar.html#recordbatch-message]
+%%
+%% [3]: [https://arrow.apache.org/docs/format/Columnar.html#encapsulated-message-format]
 %% @end
 -module(serde_arrow_ipc_message).
 -export([from_erlang/1, from_erlang/2, to_ipc/1]).
@@ -46,14 +53,17 @@
 %% Key-Value structure for custom metadata. See the definition for more info:
 %% [https://github.com/apache/arrow/blob/3456131ab7350bee5d9569ffd63d3f0ee713991c/format/Schema.fbs#L432-L439]
 
--spec from_erlang(Header :: #schema{}) -> Message :: #message{}.
+%% @doc Creates a message given a data header.
+-spec from_erlang(Header :: #schema{} | #record_batch{}) -> Message :: #message{}.
 from_erlang(Header) ->
     #message{header = Header, body_length = 0}.
 
--spec from_erlang(Header :: #schema{}, Body :: binary()) -> Message :: #message{}.
+%% @doc Creates a message given a data header and a body.
+-spec from_erlang(Header :: #schema{} | #record_batch{}, Body :: binary()) -> Message :: #message{}.
 from_erlang(Header, Body) ->
     #message{header = Header, body = Body, body_length = byte_size(Body)}.
 
+%% @doc Serializes a message into the Encapsulated Message Format.
 -spec to_ipc(Message :: #message{}) -> EMF :: binary().
 to_ipc(Message) ->
     %% 0xFFFFFFFF in int32

--- a/src/serde_arrow_ipc_message.erl
+++ b/src/serde_arrow_ipc_message.erl
@@ -33,7 +33,7 @@
 %% [2]: [https://arrow.apache.org/docs/format/Columnar.html#recordbatch-message]
 %% @end
 -module(serde_arrow_ipc_message).
--export([from_erlang/1, from_erlang/2]).
+-export([from_erlang/1, from_erlang/2, to_ipc/1]).
 -export_type([metadata_version/0, key_value/0]).
 
 -include("serde_arrow_ipc_message.hrl").
@@ -53,3 +53,14 @@ from_erlang(Header) ->
 -spec from_erlang(Header :: #schema{}, Body :: binary()) -> Message :: #message{}.
 from_erlang(Header, Body) ->
     #message{header = Header, body = Body, body_length = byte_size(Body)}.
+
+-spec to_ipc(Message :: #message{}) -> EMF :: binary().
+to_ipc(Message) ->
+    %% 0xFFFFFFFF in int32
+    Continuation = <<-1:32>>,
+    %% This is a stub value till we can serialize flatbuffers
+    Metadata = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    MetadataSize = <<(byte_size(Metadata)):32>>,
+    Body = Message#message.body,
+
+    <<Continuation/binary, MetadataSize/binary, Metadata/binary, Body/binary>>.

--- a/src/serde_arrow_ipc_message.erl
+++ b/src/serde_arrow_ipc_message.erl
@@ -33,7 +33,7 @@
 %% [2]: [https://arrow.apache.org/docs/format/Columnar.html#recordbatch-message]
 %% @end
 -module(serde_arrow_ipc_message).
--export([from_erlang/1]).
+-export([from_erlang/1, from_erlang/2]).
 -export_type([metadata_version/0, key_value/0]).
 
 -include("serde_arrow_ipc_message.hrl").
@@ -49,3 +49,7 @@
 -spec from_erlang(Header :: #schema{}) -> Message :: #message{}.
 from_erlang(Header) ->
     #message{header = Header, body_length = 0}.
+
+-spec from_erlang(Header :: #schema{}, Body :: binary()) -> Message :: #message{}.
+from_erlang(Header, Body) ->
+    #message{header = Header, body = Body, body_length = byte_size(Body)}.

--- a/src/serde_arrow_ipc_message.erl
+++ b/src/serde_arrow_ipc_message.erl
@@ -71,6 +71,12 @@ to_ipc(Message) ->
     %% This is a stub value till we can serialize flatbuffers
     Metadata = <<1, 2, 3, 4, 5, 6, 7, 8>>,
     MetadataSize = <<(byte_size(Metadata)):32>>,
-    Body = Message#message.body,
+    Body =
+        case Message#message.body of
+            undefined ->
+                <<>>;
+            Bin ->
+                Bin
+        end,
 
     <<Continuation/binary, MetadataSize/binary, Metadata/binary, Body/binary>>.

--- a/src/serde_arrow_ipc_message.hrl
+++ b/src/serde_arrow_ipc_message.hrl
@@ -1,8 +1,9 @@
 -include("serde_arrow_ipc_schema.hrl").
+-include("serde_arrow_ipc_record_batch.hrl").
 
 -record(message, {
     version = v5 :: serde_arrow_ipc_message:metadata_version(),
-    header :: #schema{},
+    header :: #schema{} | #record_batch{},
     body_length :: non_neg_integer(),
     custom_metadata = [] :: [serde_arrow_ipc_message:key_value()],
 

--- a/test/serde_arrow_ipc_message_SUITE.erl
+++ b/test/serde_arrow_ipc_message_SUITE.erl
@@ -11,9 +11,28 @@
 -define(NameField, serde_arrow_ipc_field:from_erlang({bin, undefined}, "name")).
 -define(AgeField, serde_arrow_ipc_field:from_erlang({u, 8}, "age")).
 -define(AnnualMarksField,
-    serde_arrow_ipc_field:from_erlang({fixed_list, {u, 8}, 5}, "annual_marks")
+    serde_arrow_ipc_field:from_erlang({fixed_list, {u, 8}, 3}, "annual_marks")
 ).
--define(Schema, [?IDField, ?NameField, ?AgeField, ?AnnualMarksField]).
+-define(Fields, [?IDField, ?NameField, ?AgeField, ?AnnualMarksField]).
+-define(Schema, serde_arrow_ipc_schema:from_erlang(?Fields)).
+-define(SchemaMsg, from_erlang(?Schema)).
+
+-define(ID, serde_arrow_array:from_erlang(fixed_primitive, [0, 1, 2, undefined], {s, 8})).
+-define(Name,
+    serde_arrow_array:from_erlang(
+        variable_binary, [<<"alice">>, <<"bob">>, <<"charlie">>, undefined], {bin, undefined}
+    )
+).
+-define(Age, serde_arrow_array:from_erlang(fixed_primitive, [10, 20, 30, undefined], {s, 8})).
+-define(AnnualMarks,
+    serde_arrow_array:from_erlang(
+        fixed_list, [[100, 97, 98], [100, 99, 96], [100, 98, 95], undefined], {s, 8}
+    )
+).
+-define(Columns, [?ID, ?Name, ?AnnualMarks]).
+-define(RecordBatch, serde_arrow_ipc_record_batch:from_erlang(?Columns)).
+-define(Body, <<<<(serde_arrow_array:to_arrow(Array))/binary>> || Array <- ?Columns>>).
+-define(RecordBatchMsg, from_erlang(?RecordBatch, ?Body)).
 
 all() ->
     [
@@ -25,19 +44,24 @@ all() ->
     ].
 
 valid_version_on_from_erlang(_Config) ->
-    ?assertEqual((from_erlang(?Schema))#message.version, v5).
+    ?assertEqual((?SchemaMsg)#message.version, v5),
+    ?assertEqual((?RecordBatchMsg)#message.version, v5).
 
 valid_header_on_from_erlang(_Config) ->
-    ?assertEqual((from_erlang(?Schema))#message.header, ?Schema).
+    ?assertEqual((?SchemaMsg)#message.header, ?Schema),
+    ?assertEqual((?RecordBatchMsg)#message.header, ?RecordBatch).
 
 valid_body_length_on_from_erlang(_Config) ->
-    ?assertEqual((from_erlang(?Schema))#message.body_length, 0).
+    ?assertEqual((?SchemaMsg)#message.body_length, 0),
+    ?assertEqual((?RecordBatchMsg)#message.body_length, byte_size(?Body)).
 
 valid_custom_metadata_on_from_erlang(_Config) ->
-    ?assertEqual((from_erlang(?Schema))#message.custom_metadata, []).
+    ?assertEqual((?SchemaMsg)#message.custom_metadata, []),
+    ?assertEqual((?RecordBatchMsg)#message.custom_metadata, []).
 
 valid_body_on_from_erlang(_Config) ->
-    ?assertEqual((from_erlang(?Schema))#message.body, undefined).
+    ?assertEqual((?SchemaMsg)#message.body, undefined),
+    ?assertEqual((?RecordBatchMsg)#message.body, ?Body).
 
 %%%%%%%%%%%
 %% Utils %%

--- a/test/serde_arrow_ipc_message_SUITE.erl
+++ b/test/serde_arrow_ipc_message_SUITE.erl
@@ -99,10 +99,10 @@ valid_metadata_on_to_ipc(_Config) ->
     ?assertEqual(Metadata, <<1, 2, 3, 4, 5, 6, 7, 8>>).
 
 valid_body_on_to_ipc(_Config) ->
-    <<_:32, _:32, _:8, Body1>> = ?RecordBatchEMF,
+    <<_:32, _:32, _:8/binary, Body1/binary>> = ?RecordBatchEMF,
     ?assertEqual(Body1, ?Body),
 
-    <<_:32, _:32, _:8, Body2/binary>> = ?SchemaEMF,
+    <<_:32, _:32, _:8/binary, Body2/binary>> = ?SchemaEMF,
     ?assertEqual(Body2, <<>>).
 
 %%%%%%%%%%%


### PR DESCRIPTION
This commit adds support for Schema and RecordBatch messages. However, the                                                                                                                                                                    
metadata is not serialized as that requires flatbuffers. It is because of this                                                                                                                                                                
non-serialisation that this implementation is incomplete.