### PR TITLE
Correct Typing in IPC Schemas

### DIFF
--- a/src/serde_arrow_ipc_field.erl
+++ b/src/serde_arrow_ipc_field.erl
@@ -14,7 +14,8 @@
 %%      Generally true.
 %%  </li>
 %%  <li>
-%%      `type': The Layout of the column
+%%      `type': The Type of the column, and is of type
+%%      `serde_arrow_ipc_type:ipc_type()'
 %%  </li>
 %%  <li>
 %%      `dictionary': A boolean representing if the column is dictionary encoded
@@ -35,29 +36,26 @@
 %% [2]: [https://github.com/apache/arrow/blob/3456131ab7350bee5d9569ffd63d3f0ee713991c/format/Schema.fbs#L514-L530]
 %% @end
 -module(serde_arrow_ipc_field).
--export([from_erlang/1, from_erlang/2]).
+-export([from_erlang/1, from_erlang/2, from_erlang/3]).
 
 -include("serde_arrow_ipc_schema.hrl").
 
 %% @doc Creates a field given the type of the column. Assigns the name as
 %% `undefined'.
--spec from_erlang(Type :: serde_arrow_type:arrow_longhand_type()) -> Field :: #field{}.
+-spec from_erlang(Type :: serde_arrow_ipc_type:ipc_type()) -> Field :: #field{}.
 from_erlang(Type) ->
-    from_erlang(Type, undefined).
+    from_erlang(Type, undefined, []).
 
 %% @doc Creates a field given the type and name of the column.
--spec from_erlang(Type :: serdelayoutow_type:arrow_longhand_type(), Name :: string() | undefined) ->
+-spec from_erlang(Type :: serde_arrow_ipc_type:ipc_type(), Name :: string() | undefined) ->
     Field :: #field{}.
-from_erlang(Type, Name) when tuple_size(Type) =:= 2 ->
-    #field{name = Name, type = layout(Type)};
-from_erlang({_, NestedType, _} = Type, Name) ->
-    #field{name = Name, type = layout(Type), children = [from_erlang(NestedType)]}.
+from_erlang(Type, Name) ->
+    from_erlang(Type, Name, []).
 
--spec layout(Type :: serde_arrow_type:arrow_longhand_type()) ->
-    Layout :: serde_arrow_array:layout().
-layout({_, Size}) when is_integer(Size) ->
-    fixed_primitive;
-layout({_, undefined}) ->
-    variable_binary;
-layout({Layout, _, _}) ->
-    Layout.
+%% @doc Creates a field given the type, name and children of the column.
+-spec from_erlang(
+    Type :: serde_arrow_ipc_type:ipc_type(), Name :: string() | undefined, Children :: [#field{}]
+) ->
+    Field :: #field{}.
+from_erlang(Type, Name, Children) ->
+    #field{name = Name, type = Type, children = Children}.

--- a/src/serde_arrow_ipc_field.hrl
+++ b/src/serde_arrow_ipc_field.hrl
@@ -1,7 +1,7 @@
 -record(field, {
     name :: string() | undefined,
     nullable = true :: boolean(),
-    type :: serde_arrow_array:layout(),
+    type :: serde_arrow_ipc_type:ipc_type(),
     dictionary = undefined,
     children = [] :: [#field{}],
     custom_metadata = [] :: [serde_arrow_ipc_message:key_value()]

--- a/src/serde_arrow_ipc_type.erl
+++ b/src/serde_arrow_ipc_type.erl
@@ -1,14 +1,27 @@
 %% @doc Provides types and functions to work with IPC types.
+%%
+%% This module provides functions and types to produce the types in IPC Schema
+%% definitions[1]. These types are generated according to these[2] definitions.
+%% The types have been represented in the form `{TypeName, Metadata}', where
+%% TypeName is the name of the type and is an atom, and Metadata is a map of all
+%% the metadata associated with it.
+%%
+%% [1]:https://github.com/apache/arrow/blob/main/format/Schema.fbs
+%%
+%% [2]: https://github.com/apache/arrow/blob/main/format/Schema.fbs#L82-L430
+%% @end
 -module(serde_arrow_ipc_type).
+-export([from_erlang/1]).
 -export_type([
     ipc_type/0,
     int/0,
     floating_point/0,
-    fixed_size_binary/0,
     fixed_size_list/0,
     large_binary/0,
     large_list/0
 ]).
+
+-include("serde_arrow_array.hrl").
 
 %% TODO: Add support for the commented types.
 %%
@@ -29,7 +42,7 @@
     %% | list()
     %% | struct_()
     %% | union()
-    | fixed_size_binary()
+    %% | fixed_size_binary()
     | fixed_size_list()
     %% | map()
     %% | duration()
@@ -46,14 +59,41 @@
 -type floating_point() :: {floating_point, #{precision => half | single | double}}.
 %% Represents a Fixed-Size Primitive Layout Array of f16, f32 or f64.
 
--type fixed_size_binary() :: {fixed_size_binary, #{byte_width => pos_integer()}}.
-%% Represents a Fixed-Size Binary Layout Array.
-
 -type fixed_size_list() :: {fixed_size_list, #{list_size => pos_integer()}}.
-%% Represents a Fixed-Size Binary Layout Array.
+%% Represents a Fixed-Size List Layout Array.
 
 -type large_binary() :: {large_binary, undefined}.
 %% Represents a Variable-Size Binary Layout Array with 64 bit offsets.
 
 -type large_list() :: {large_list, undefined}.
 %% Represents a Variable-Size List Layout Array with 64 bit offsets.
+
+%%%%%%%%%%%%%%%%%%%
+%% from_erlang/1 %%
+%%%%%%%%%%%%%%%%%%%
+
+%% @doc Returns the IPC Type for an `#array{}`.
+-spec from_erlang(Array :: serde_arrow_array:array()) -> Type :: ipc_type().
+from_erlang(Array) ->
+    case Array#array.layout of
+        fixed_primitive -> primitive_type(Array#array.type);
+        variable_binary -> {large_binary, undefined};
+        fixed_list -> {fixed_size_list, #{list_size => Array#array.element_len}};
+        variable_list -> {large_list, undefined}
+    end.
+
+-spec primitive_type(Type :: serde_arrow_type:arrow_longhand_type()) ->
+    IPCType :: int() | floating_point().
+primitive_type({s, Size}) ->
+    {int, #{bit_width => Size, is_signed => true}};
+primitive_type({u, Size}) ->
+    {int, #{bit_width => Size, is_signed => false}};
+primitive_type({f, Size}) ->
+    {floating_point, #{
+        precision =>
+            case Size of
+                16 -> half;
+                32 -> single;
+                64 -> double
+            end
+    }}.

--- a/src/serde_arrow_ipc_type.erl
+++ b/src/serde_arrow_ipc_type.erl
@@ -1,0 +1,59 @@
+%% @doc Provides types and functions to work with IPC types.
+-module(serde_arrow_ipc_type).
+-export_type([
+    ipc_type/0,
+    int/0,
+    floating_point/0,
+    fixed_size_binary/0,
+    fixed_size_list/0,
+    large_binary/0,
+    large_list/0
+]).
+
+%% TODO: Add support for the commented types.
+%%
+%% Note that the types have been listed in the same order as the have been
+%% defined in the Schema definitions.
+-type ipc_type() ::
+    %% null() |
+    int()
+    | floating_point()
+    %% | binary()
+    %% | utf8()
+    %% | bool()
+    %% | decimal()
+    %% | data()
+    %% | time()
+    %% | timestamp()
+    %% | interval()
+    %% | list()
+    %% | struct_()
+    %% | union()
+    | fixed_size_binary()
+    | fixed_size_list()
+    %% | map()
+    %% | duration()
+    | large_binary()
+    %% | large_utf8()
+    | large_list()
+%% | run_end_encoded()
+.
+%% Represents and IPC Type. Of the from `{TypeName, Metadata}'.
+
+-type int() :: {int, #{bit_width => pos_integer(), is_signed => boolean()}}.
+%% Represents a Fixed-Size Primitive Layout Array of an integral type.
+
+-type floating_point() :: {floating_point, #{precision => half | single | double}}.
+%% Represents a Fixed-Size Primitive Layout Array of f16, f32 or f64.
+
+-type fixed_size_binary() :: {fixed_size_binary, #{byte_width => pos_integer()}}.
+%% Represents a Fixed-Size Binary Layout Array.
+
+-type fixed_size_list() :: {fixed_size_list, #{list_size => pos_integer()}}.
+%% Represents a Fixed-Size Binary Layout Array.
+
+-type large_binary() :: {large_binary, undefined}.
+%% Represents a Variable-Size Binary Layout Array with 64 bit offsets.
+
+-type large_list() :: {large_list, undefined}.
+%% Represents a Variable-Size List Layout Array with 64 bit offsets.

--- a/src/serde_arrow_ipc_type.erl
+++ b/src/serde_arrow_ipc_type.erl
@@ -72,7 +72,7 @@
 %% from_erlang/1 %%
 %%%%%%%%%%%%%%%%%%%
 
-%% @doc Returns the IPC Type for an `#array{}`.
+%% @doc Returns the IPC Type for an `#array{}'.
 -spec from_erlang(Array :: serde_arrow_array:array()) -> Type :: ipc_type().
 from_erlang(Array) ->
     case Array#array.layout of

--- a/test/serde_arrow_ipc_field_SUITE.erl
+++ b/test/serde_arrow_ipc_field_SUITE.erl
@@ -7,6 +7,8 @@
 
 -include("serde_arrow_ipc_field.hrl").
 
+-define(S8, {int, #{bit_width => 8, is_signed => true}}).
+
 all() ->
     [
         valid_name_on_from_erlang,
@@ -18,39 +20,30 @@ all() ->
     ].
 
 valid_name_on_from_erlang(_Config) ->
-    Field1 = from_erlang({s, 8}, "id"),
+    Field1 = from_erlang(?S8, "id"),
     ?assertEqual(Field1#field.name, "id"),
 
-    Field2 = from_erlang({s, 8}),
+    Field2 = from_erlang(?S8),
     ?assertEqual(Field2#field.name, undefined).
 
 valid_nullable_on_from_erlang(_Config) ->
-    ?assertEqual((from_erlang({s, 8}))#field.nullable, true).
+    ?assertEqual((from_erlang(?S8))#field.nullable, true).
 
 valid_type_on_from_erlang(_Config) ->
-    ?assertEqual((from_erlang({s, 8}))#field.type, fixed_primitive),
-    ?assertEqual((from_erlang({bin, undefined}))#field.type, variable_binary),
-    ?assertEqual((from_erlang({fixed_list, {s, 8}, 4}))#field.type, fixed_list),
-    ?assertEqual((from_erlang({variable_list, {s, 8}, undefined}))#field.type, variable_list).
+    ?assertEqual((from_erlang(?S8))#field.type, ?S8).
 
 valid_dictionary_on_from_erlang(_Config) ->
-    ?assertEqual((from_erlang({s, 8}))#field.dictionary, undefined).
+    ?assertEqual((from_erlang(?S8))#field.dictionary, undefined).
 
 valid_children_on_from_erlang(_Config) ->
-    Field1 = from_erlang({s, 8}),
+    Field1 = from_erlang(?S8),
     ?assertEqual(Field1#field.children, []),
 
-    Field2 = from_erlang({bin, undefined}),
-    ?assertEqual(Field2#field.children, []),
-
-    Field3 = from_erlang({fixed_list, {s, 8}, 4}),
-    ?assertEqual(Field3#field.children, [Field1]),
-
-    Field4 = from_erlang({variable_list, {s, 8}, undefined}),
-    ?assertEqual(Field4#field.children, [Field1]).
+    Field2 = from_erlang({large_list, undefined}, undefined, [Field1]),
+    ?assertEqual(Field2#field.children, [Field1]).
 
 valid_custom_metadata_on_from_erlang(_Config) ->
-    ?assertEqual((from_erlang({s, 8}))#field.custom_metadata, []).
+    ?assertEqual((from_erlang(?S8))#field.custom_metadata, []).
 
 %%%%%%%%%%%
 %% Utils %%
@@ -61,3 +54,6 @@ from_erlang(X) ->
 
 from_erlang(X, Y) ->
     serde_arrow_ipc_field:from_erlang(X, Y).
+
+from_erlang(X, Y, Z) ->
+    serde_arrow_ipc_field:from_erlang(X, Y, Z).

--- a/test/serde_arrow_ipc_marks_data.hrl
+++ b/test/serde_arrow_ipc_marks_data.hrl
@@ -14,7 +14,7 @@
 ).
 -define(AnnualMarksField,
     serde_arrow_ipc_field:from_erlang(
-        {fixed_size_list, #{list_size => pos_integer()}}, "annual_marks", [
+        {fixed_size_list, #{list_size => 3}}, "annual_marks", [
             serde_arrow_ipc_field:from_erlang(
                 {int, #{bit_width => 8, is_signed => false}}
             )

--- a/test/serde_arrow_ipc_marks_data.hrl
+++ b/test/serde_arrow_ipc_marks_data.hrl
@@ -5,11 +5,21 @@
 %% Schema Encapsulated Message %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--define(IDField, serde_arrow_ipc_field:from_erlang({s, 8}, "id")).
--define(NameField, serde_arrow_ipc_field:from_erlang({bin, undefined}, "name")).
--define(AgeField, serde_arrow_ipc_field:from_erlang({u, 8}, "age")).
+-define(IDField,
+    serde_arrow_ipc_field:from_erlang({int, #{bit_width => 8, is_signed => true}}, "id")
+).
+-define(NameField, serde_arrow_ipc_field:from_erlang({variable_binary, undefined}, "name")).
+-define(AgeField,
+    serde_arrow_ipc_field:from_erlang({int, #{bit_width => 8, is_signed => false}}, "age")
+).
 -define(AnnualMarksField,
-    serde_arrow_ipc_field:from_erlang({fixed_list, {u, 8}, 3}, "annual_marks")
+    serde_arrow_ipc_field:from_erlang(
+        {fixed_size_list, #{list_size => pos_integer()}}, "annual_marks", [
+            serde_arrow_ipc_field:from_erlang(
+                {int, #{bit_width => 8, is_signed => false}}
+            )
+        ]
+    )
 ).
 -define(Fields, [?IDField, ?NameField, ?AgeField, ?AnnualMarksField]).
 -define(Schema, serde_arrow_ipc_schema:from_erlang(?Fields)).


### PR DESCRIPTION
This commit fixes the type definitions in `ipc_field` to match that in the
schema definitions: https://github.com/apache/arrow/blob/main/format/Schema.fbs#L82-L430.
