### PR TITLE
Correct Typing in Rust

### DIFF
--- a/native/arrow_format_nif/src/lib.rs
+++ b/native/arrow_format_nif/src/lib.rs
@@ -5,6 +5,7 @@ mod utils;
 
 use message::record_batch::{Buffer, Compression, FieldNode, RecordBatch};
 use message::schema::field::{Field, Name};
+use message::schema::types::{FixedSizeList, Int, Type};
 use message::schema::{Endianness, Feature, Schema};
 use message::{Header, Message, Version};
 
@@ -74,7 +75,10 @@ fn test_encode(msg_type: Atom) -> Message {
                     Field {
                         name: Name::from("id"),
                         nullable: true,
-                        r#type: atoms::fixed_primitive(),
+                        r#type: Type::Int(Int {
+                            bit_width: 8,
+                            is_signed: true,
+                        }),
                         dictionary: atoms::undefined(),
                         children: vec![],
                         custom_metadata: vec![],
@@ -82,7 +86,7 @@ fn test_encode(msg_type: Atom) -> Message {
                     Field {
                         name: Name::from("name"),
                         nullable: true,
-                        r#type: atoms::variable_binary(),
+                        r#type: Type::LargeBinary,
                         dictionary: atoms::undefined(),
                         children: vec![],
                         custom_metadata: vec![],
@@ -90,7 +94,10 @@ fn test_encode(msg_type: Atom) -> Message {
                     Field {
                         name: Name::from("age"),
                         nullable: true,
-                        r#type: atoms::fixed_primitive(),
+                        r#type: Type::Int(Int {
+                            bit_width: 8,
+                            is_signed: false,
+                        }),
                         dictionary: atoms::undefined(),
                         children: vec![],
                         custom_metadata: vec![],
@@ -98,12 +105,15 @@ fn test_encode(msg_type: Atom) -> Message {
                     Field {
                         name: Name::from("annual_marks"),
                         nullable: true,
-                        r#type: atoms::fixed_list(),
+                        r#type: Type::FixedSizeList(FixedSizeList { list_size: 3 }),
                         dictionary: atoms::undefined(),
                         children: vec![Field {
                             name: Name::Atom(atoms::undefined()),
                             nullable: true,
-                            r#type: atoms::fixed_primitive(),
+                            r#type: Type::Int(Int {
+                                bit_width: 8,
+                                is_signed: false,
+                            }),
                             dictionary: atoms::undefined(),
                             children: vec![],
                             custom_metadata: vec![],

--- a/native/arrow_format_nif/src/message/schema.rs
+++ b/native/arrow_format_nif/src/message/schema.rs
@@ -2,6 +2,7 @@ use crate::utils::CustomMetadata;
 use rustler::{NifRecord, NifUnitEnum};
 
 pub mod field;
+pub mod types;
 
 use field::Field;
 

--- a/native/arrow_format_nif/src/message/schema/field.rs
+++ b/native/arrow_format_nif/src/message/schema/field.rs
@@ -1,12 +1,14 @@
 use crate::utils::CustomMetadata;
 use rustler::{Atom, Decoder, Encoder, NifRecord, Term};
 
+use super::types::Type;
+
 #[derive(Debug, NifRecord)]
 #[tag = "field"]
 pub struct Field {
     pub name: Name,
     pub nullable: bool,
-    pub r#type: Atom,
+    pub r#type: Type,
     pub dictionary: Atom,
     pub children: Vec<Field>,
     pub custom_metadata: CustomMetadata,

--- a/native/arrow_format_nif/src/message/schema/types.rs
+++ b/native/arrow_format_nif/src/message/schema/types.rs
@@ -1,0 +1,34 @@
+#![allow(clippy::needless_borrow)]
+use rustler::{NifMap, NifTaggedEnum};
+
+#[derive(Debug, NifTaggedEnum)]
+pub enum Type {
+    Int(Int),
+    FloatingPoint(FloatingPoint),
+    FixedSizeList(FixedSizeList),
+    LargeBinary,
+    LargeList,
+}
+
+#[derive(Debug, NifMap)]
+pub struct Int {
+    pub bit_width: i64,
+    pub is_signed: bool,
+}
+
+#[derive(Debug, NifMap)]
+pub struct FloatingPoint {
+    pub precision: Precision,
+}
+
+#[derive(Debug, NifTaggedEnum)]
+pub enum Precision {
+    Half,
+    Single,
+    Double,
+}
+
+#[derive(Debug, NifMap)]
+pub struct FixedSizeList {
+    pub list_size: i64,
+}

--- a/src/serde_arrow_ipc_type.erl
+++ b/src/serde_arrow_ipc_type.erl
@@ -3,8 +3,9 @@
 %% This module provides functions and types to produce the types in IPC Schema
 %% definitions[1]. These types are generated according to these[2] definitions.
 %% The types have been represented in the form `{TypeName, Metadata}', where
-%% TypeName is the name of the type and is an atom, and Metadata is a map of all
-%% the metadata associated with it.
+%% `TypeName' is the name of the type and is an atom, and `Metadata' is a map of
+%% all the metadata associated with it. In case a type has no metadata
+%% associated with it, it is represented as just `TypeName'
 %%
 %% [1]:https://github.com/apache/arrow/blob/main/format/Schema.fbs
 %%
@@ -62,10 +63,10 @@
 -type fixed_size_list() :: {fixed_size_list, #{list_size => pos_integer()}}.
 %% Represents a Fixed-Size List Layout Array.
 
--type large_binary() :: {large_binary, undefined}.
+-type large_binary() :: large_binary.
 %% Represents a Variable-Size Binary Layout Array with 64 bit offsets.
 
--type large_list() :: {large_list, undefined}.
+-type large_list() :: large_list.
 %% Represents a Variable-Size List Layout Array with 64 bit offsets.
 
 %%%%%%%%%%%%%%%%%%%
@@ -77,9 +78,9 @@
 from_erlang(Array) ->
     case Array#array.layout of
         fixed_primitive -> primitive_type(Array#array.type);
-        variable_binary -> {large_binary, undefined};
+        variable_binary -> large_binary;
         fixed_list -> {fixed_size_list, #{list_size => Array#array.element_len}};
-        variable_list -> {large_list, undefined}
+        variable_list -> large_list
     end.
 
 -spec primitive_type(Type :: serde_arrow_type:arrow_longhand_type()) ->

--- a/test/arrow_format_nif_SUITE.erl
+++ b/test/arrow_format_nif_SUITE.erl
@@ -17,6 +17,35 @@ all() ->
 %%%%%%%%%%%%%%%%%
 
 test_decode(_Config) ->
+    %% Type testing
+
+    %% Signed Integers
+    ?assertEqual(arrow_format_nif:test_decode(schema({int, #{bit_width => 8, is_signed => true}})), ok),
+    ?assertEqual(arrow_format_nif:test_decode(schema({int, #{bit_width => 16, is_signed => true}})), ok),
+    ?assertEqual(arrow_format_nif:test_decode(schema({int, #{bit_width => 32, is_signed => true}})), ok),
+    ?assertEqual(arrow_format_nif:test_decode(schema({int, #{bit_width => 64, is_signed => true}})), ok),
+
+    %% Unsigned Integers
+    ?assertEqual(arrow_format_nif:test_decode(schema({int, #{bit_width => 8, is_signed => false}})), ok),
+    ?assertEqual(arrow_format_nif:test_decode(schema({int, #{bit_width => 16, is_signed => false}})), ok),
+    ?assertEqual(arrow_format_nif:test_decode(schema({int, #{bit_width => 32, is_signed => false}})), ok),
+    ?assertEqual(arrow_format_nif:test_decode(schema({int, #{bit_width => 64, is_signed => false}})), ok),
+
+    %% Floating Point
+    ?assertEqual(arrow_format_nif:test_decode(schema({floating_point, #{precision => half}})), ok),
+    ?assertEqual(arrow_format_nif:test_decode(schema({floating_point, #{precision => single}})), ok),
+    ?assertEqual(arrow_format_nif:test_decode(schema({floating_point, #{precision => double}})), ok),
+
+    %% Fixed-Size List
+    ?assertEqual(arrow_format_nif:test_decode(schema({fixed_size_list, #{list_size => 3}})), ok),
+
+    %% Large Binary
+    ?assertEqual(arrow_format_nif:test_decode(schema(large_binary)), ok),
+
+    %% Large List
+    ?assertEqual(arrow_format_nif:test_decode(schema(large_list)), ok),
+
+    %% Test using the Marks Data
     ?assertEqual(arrow_format_nif:test_decode(?SchemaMsg), ok),
 
     %% Flatbuffers doesn't need the body. So, don't provide it.
@@ -33,3 +62,10 @@ test_encode(_Config) ->
     %% Flatbuffers can't access the body. So, the NIF won't return it.
     RecordBatchMsg = (?RecordBatchMsg)#message{body = undefined},
     ?assertEqual(arrow_format_nif:test_encode(record_batch), RecordBatchMsg).
+
+%%%%%%%%%%%
+%% Utils %%
+%%%%%%%%%%%
+
+schema(Type) ->
+    serde_arrow_ipc_message:from_erlang(serde_arrow_ipc_schema:from_erlang([serde_arrow_ipc_field:from_erlang(Type)])).

--- a/test/arrow_format_nif_SUITE.erl
+++ b/test/arrow_format_nif_SUITE.erl
@@ -20,21 +20,41 @@ test_decode(_Config) ->
     %% Type testing
 
     %% Signed Integers
-    ?assertEqual(arrow_format_nif:test_decode(schema({int, #{bit_width => 8, is_signed => true}})), ok),
-    ?assertEqual(arrow_format_nif:test_decode(schema({int, #{bit_width => 16, is_signed => true}})), ok),
-    ?assertEqual(arrow_format_nif:test_decode(schema({int, #{bit_width => 32, is_signed => true}})), ok),
-    ?assertEqual(arrow_format_nif:test_decode(schema({int, #{bit_width => 64, is_signed => true}})), ok),
+    ?assertEqual(
+        arrow_format_nif:test_decode(schema({int, #{bit_width => 8, is_signed => true}})), ok
+    ),
+    ?assertEqual(
+        arrow_format_nif:test_decode(schema({int, #{bit_width => 16, is_signed => true}})), ok
+    ),
+    ?assertEqual(
+        arrow_format_nif:test_decode(schema({int, #{bit_width => 32, is_signed => true}})), ok
+    ),
+    ?assertEqual(
+        arrow_format_nif:test_decode(schema({int, #{bit_width => 64, is_signed => true}})), ok
+    ),
 
     %% Unsigned Integers
-    ?assertEqual(arrow_format_nif:test_decode(schema({int, #{bit_width => 8, is_signed => false}})), ok),
-    ?assertEqual(arrow_format_nif:test_decode(schema({int, #{bit_width => 16, is_signed => false}})), ok),
-    ?assertEqual(arrow_format_nif:test_decode(schema({int, #{bit_width => 32, is_signed => false}})), ok),
-    ?assertEqual(arrow_format_nif:test_decode(schema({int, #{bit_width => 64, is_signed => false}})), ok),
+    ?assertEqual(
+        arrow_format_nif:test_decode(schema({int, #{bit_width => 8, is_signed => false}})), ok
+    ),
+    ?assertEqual(
+        arrow_format_nif:test_decode(schema({int, #{bit_width => 16, is_signed => false}})), ok
+    ),
+    ?assertEqual(
+        arrow_format_nif:test_decode(schema({int, #{bit_width => 32, is_signed => false}})), ok
+    ),
+    ?assertEqual(
+        arrow_format_nif:test_decode(schema({int, #{bit_width => 64, is_signed => false}})), ok
+    ),
 
     %% Floating Point
     ?assertEqual(arrow_format_nif:test_decode(schema({floating_point, #{precision => half}})), ok),
-    ?assertEqual(arrow_format_nif:test_decode(schema({floating_point, #{precision => single}})), ok),
-    ?assertEqual(arrow_format_nif:test_decode(schema({floating_point, #{precision => double}})), ok),
+    ?assertEqual(
+        arrow_format_nif:test_decode(schema({floating_point, #{precision => single}})), ok
+    ),
+    ?assertEqual(
+        arrow_format_nif:test_decode(schema({floating_point, #{precision => double}})), ok
+    ),
 
     %% Fixed-Size List
     ?assertEqual(arrow_format_nif:test_decode(schema({fixed_size_list, #{list_size => 3}})), ok),
@@ -68,4 +88,6 @@ test_encode(_Config) ->
 %%%%%%%%%%%
 
 schema(Type) ->
-    serde_arrow_ipc_message:from_erlang(serde_arrow_ipc_schema:from_erlang([serde_arrow_ipc_field:from_erlang(Type)])).
+    serde_arrow_ipc_message:from_erlang(
+        serde_arrow_ipc_schema:from_erlang([serde_arrow_ipc_field:from_erlang(Type)])
+    ).

--- a/test/serde_arrow_ipc_field_SUITE.erl
+++ b/test/serde_arrow_ipc_field_SUITE.erl
@@ -39,7 +39,7 @@ valid_children_on_from_erlang(_Config) ->
     Field1 = from_erlang(?S8),
     ?assertEqual(Field1#field.children, []),
 
-    Field2 = from_erlang({large_list, undefined}, undefined, [Field1]),
+    Field2 = from_erlang(large_list, undefined, [Field1]),
     ?assertEqual(Field2#field.children, [Field1]).
 
 valid_custom_metadata_on_from_erlang(_Config) ->

--- a/test/serde_arrow_ipc_marks_data.hrl
+++ b/test/serde_arrow_ipc_marks_data.hrl
@@ -8,7 +8,7 @@
 -define(IDField,
     serde_arrow_ipc_field:from_erlang({int, #{bit_width => 8, is_signed => true}}, "id")
 ).
--define(NameField, serde_arrow_ipc_field:from_erlang({variable_binary, undefined}, "name")).
+-define(NameField, serde_arrow_ipc_field:from_erlang(large_binary, "name")).
 -define(AgeField,
     serde_arrow_ipc_field:from_erlang({int, #{bit_width => 8, is_signed => false}}, "age")
 ).

--- a/test/serde_arrow_ipc_type_SUITE.erl
+++ b/test/serde_arrow_ipc_type_SUITE.erl
@@ -1,0 +1,61 @@
+-module(serde_arrow_ipc_type_SUITE).
+
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-include("serde_arrow_ipc_marks_data.hrl").
+
+all() ->
+    [
+        int_from_erlang,
+        floating_point_from_erlang,
+        fixed_size_list_from_erlang,
+        large_binary_from_erlang,
+        large_list_from_erlang
+    ].
+
+int_from_erlang(_Config) ->
+    %% Signed Integers
+    ?assertEqual(fixed_primitive(s8), {int, #{bit_width => 8, is_signed => true}}),
+    ?assertEqual(fixed_primitive(s16), {int, #{bit_width => 16, is_signed => true}}),
+    ?assertEqual(fixed_primitive(s32), {int, #{bit_width => 32, is_signed => true}}),
+    ?assertEqual(fixed_primitive(s64), {int, #{bit_width => 64, is_signed => true}}),
+
+    %% Unsigned Integers
+    ?assertEqual(fixed_primitive(u8), {int, #{bit_width => 8, is_signed => false}}),
+    ?assertEqual(fixed_primitive(u16), {int, #{bit_width => 16, is_signed => false}}),
+    ?assertEqual(fixed_primitive(u32), {int, #{bit_width => 32, is_signed => false}}),
+    ?assertEqual(fixed_primitive(u64), {int, #{bit_width => 64, is_signed => false}}).
+
+floating_point_from_erlang(_Config) ->
+    ?assertEqual(fixed_primitive(f16), {floating_point, #{precision => half}}),
+    ?assertEqual(fixed_primitive(f32), {floating_point, #{precision => single}}),
+    ?assertEqual(fixed_primitive(f64), {floating_point, #{precision => double}}).
+
+fixed_size_list_from_erlang(_Config) ->
+    Type = from_erlang(serde_arrow_fixed_list_array:from_erlang([[1, 2, 3]], {s, 8})),
+    ?assertEqual(Type, {fixed_size_list, #{list_size => 3}}).
+
+large_binary_from_erlang(_Config) ->
+    Type = from_erlang(
+        serde_arrow_variable_binary_array:from_erlang([<<1>>, <<1, 2>>, <<1, 2, 3>>], {s, 8})
+    ),
+    ?assertEqual(Type, large_binary).
+
+large_list_from_erlang(_Config) ->
+    Type = from_erlang(
+        serde_arrow_variable_list_array:from_erlang([[1], [1, 2], [1, 2, 3]], {s, 8})
+    ),
+    ?assertEqual(Type, large_list).
+
+%%%%%%%%%%%
+%% Utils %%
+%%%%%%%%%%%
+
+fixed_primitive(Type) ->
+    from_erlang(serde_arrow_fixed_primitive_array:from_erlang([1, 2, 3], Type)).
+
+from_erlang(Array) ->
+    serde_arrow_ipc_type:from_erlang(Array).


### PR DESCRIPTION
This commit corrects the typing in Rust. See #30. 

