### PR TITLE
Run Erlang and Rust tests separately in the CI

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -60,3 +60,28 @@ jobs:
 
       - name: run rustfmt
         run: cargo fmt --manifest-path=${{ matrix.manifest }} --all -- --check
+
+  test-rust:
+    name: Run unittests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        manifest:
+          - native/arrow_format_nif/Cargo.toml
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
+          components: rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          env-vars: "RUST_TOOLCHAIN_VERSION"
+          workspaces: |
+            native/arrow_format_nif
+
+      - name: run cargo test
+        run: cargo test --manifest-path=${{ matrix.manifest }}

--- a/rebar.config
+++ b/rebar.config
@@ -40,6 +40,5 @@
     ]},
     {post, [
         {clean, {cargo, clean}},
-        {ct, {cargo, test}}
     ]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -39,6 +39,6 @@
         {compile, {cargo, build}}
     ]},
     {post, [
-        {clean, {cargo, clean}},
+        {clean, {cargo, clean}}
     ]}
 ]}.


### PR DESCRIPTION
Currently the Rust unit tests are run via rebar3 as a post hook to ct.
This commit changes it so that the tests are run in their separate
language workflows instead.
