### PR TITLE
Fix failing tests

### DIFF
--- a/.github/workflows/erlang-ci.yml
+++ b/.github/workflows/erlang-ci.yml
@@ -144,8 +144,5 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-hex-
 
-      - name: Compile
-        run: rebar3 as docs compile
-
       - name: Generate Docs
         run: rebar3 ex_doc

--- a/.github/workflows/erlang-ci.yml
+++ b/.github/workflows/erlang-ci.yml
@@ -145,7 +145,7 @@ jobs:
             ${{ runner.os }}-hex-
 
       - name: Compile
-        run: rebar3 compile
+        run: rebar3 as docs compile
 
       - name: Generate Docs
         run: rebar3 ex_doc

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
     ]}
 ]}.
 
-{project_plugins, [erlfmt, rebar3_ex_doc, rebar3_cargo]}.
+{project_plugins, [erlfmt, {rebar3_ex_doc, "0.2.18"}, rebar3_cargo]}.
 
 % Let erlfmt write files on format as opposed to not doing anything
 {erlfmt, [write]}.


### PR DESCRIPTION
The latest rebar3_ex_doc version has broken our docs. This commit
reverts it to the previous version.
