### PR TITLE
Serialize Message Metadata in ipc_message:to_ipc

### DIFF
--- a/src/serde_arrow_ipc_message.erl
+++ b/src/serde_arrow_ipc_message.erl
@@ -69,7 +69,7 @@ to_ipc(Message) ->
     %% 0xFFFFFFFF in int32
     Continuation = <<-1:32>>,
     %% This is a stub value till we can serialize flatbuffers
-    Metadata = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    Metadata = arrow_format_nif:serialize_message(Message#message{body = undefined}),
     MetadataSize = <<(byte_size(Metadata)):32>>,
     Body =
         case Message#message.body of

--- a/test/serde_arrow_ipc_message_SUITE.erl
+++ b/test/serde_arrow_ipc_message_SUITE.erl
@@ -59,17 +59,18 @@ valid_continuation_on_to_ipc(_Config) ->
 
 valid_metadata_size_on_to_ipc(_Config) ->
     <<_:32, MetadataSize:32, _Rest/binary>> = ?RecordBatchEMF,
-    ?assertEqual(MetadataSize, 8).
+    ?assertEqual(MetadataSize, 300).
 
 valid_metadata_on_to_ipc(_Config) ->
-    <<_:32, _:32, Metadata:8/binary, _Rest/binary>> = ?RecordBatchEMF,
-    ?assertEqual(Metadata, <<1, 2, 3, 4, 5, 6, 7, 8>>).
+    <<_:32, _:32, MsgMetadata:300/binary, _Rest/binary>> = ?RecordBatchEMF,
+    PlainMetadata = arrow_format_nif:serialize_message((?RecordBatchMsg)#message{body = undefined}),
+    ?assertEqual(MsgMetadata, PlainMetadata).
 
 valid_body_on_to_ipc(_Config) ->
-    <<_:32, _:32, _:8/binary, Body1/binary>> = ?RecordBatchEMF,
+    <<_:32, _:32, _:300/binary, Body1/binary>> = ?RecordBatchEMF,
     ?assertEqual(Body1, ?Body),
 
-    <<_:32, _:32, _:8/binary, Body2/binary>> = ?SchemaEMF,
+    <<_:32, _:32, _:363/binary, Body2/binary>> = ?SchemaEMF,
     ?assertEqual(Body2, <<>>).
 
 %%%%%%%%%%%%%%%%%
@@ -77,7 +78,7 @@ valid_body_on_to_ipc(_Config) ->
 %%%%%%%%%%%%%%%%%
 
 valid_stream_on_to_stream(_Config) ->
-    <<Schema:16/binary, RecordBatch:656/binary, EOS/binary>> = ?Stream,
+    <<Schema:371/binary, RecordBatch:948/binary, EOS/binary>> = ?Stream,
 
     ?assertEqual(Schema, ?SchemaEMF),
     ?assertEqual(RecordBatch, ?RecordBatchEMF),


### PR DESCRIPTION
This commit adds the final step to support message metadata
serialization: to use `arrow_format_nif` to serialize the metadata in
the `serde_arrow_ipc_mesage:to_ipc` function.

As part of serializing metadata in `to_ipc`, the CommonTests have been
updated to test expecting valid metadata instead of a stub.
