### PR TITLE
Update Rustler to 0.35.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_TOOLCHAIN_VERSION: stable-2024-04-29
+  RUST_TOOLCHAIN_VERSION: stable
 
 jobs:
   deploy:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_TOOLCHAIN_VERSION: nightly-2023-06-01
+  RUST_TOOLCHAIN_VERSION: 2024-04-29
 
 jobs:
   deploy:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_TOOLCHAIN_VERSION: 2024-04-29
+  RUST_TOOLCHAIN_VERSION: stable-2024-04-29
 
 jobs:
   deploy:

--- a/.github/workflows/erlang-ci.yml
+++ b/.github/workflows/erlang-ci.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  RUST_TOOLCHAIN_VERSION: nightly-2023-06-01
+  RUST_TOOLCHAIN_VERSION: 2024-04-29
 
 jobs:
   format:

--- a/.github/workflows/erlang-ci.yml
+++ b/.github/workflows/erlang-ci.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  RUST_TOOLCHAIN_VERSION: 2024-04-29
+  RUST_TOOLCHAIN_VERSION: stable-2024-04-29
 
 jobs:
   format:

--- a/.github/workflows/erlang-ci.yml
+++ b/.github/workflows/erlang-ci.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  RUST_TOOLCHAIN_VERSION: stable-2024-04-29
+  RUST_TOOLCHAIN_VERSION: stable
 
 jobs:
   format:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  RUST_TOOLCHAIN_VERSION: stable-2024-04-29
+  RUST_TOOLCHAIN_VERSION: stable
 
 jobs:
   lint-rust:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  RUST_TOOLCHAIN_VERSION: 2024-04-29
+  RUST_TOOLCHAIN_VERSION: stable-2024-04-29
 
 jobs:
   lint-rust:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  RUST_TOOLCHAIN_VERSION: nightly-2023-06-01
+  RUST_TOOLCHAIN_VERSION: 2024-04-29
 
 jobs:
   lint-rust:

--- a/native/arrow_format_nif/Cargo.lock
+++ b/native/arrow_format_nif/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "array-init-cursor"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,22 +27,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
+name = "inventory"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
-name = "memchr"
-version = "2.5.0"
+name = "libloading"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
 
 [[package]]
 name = "planus"
@@ -81,53 +82,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.8.4"
+name = "regex-lite"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "rustler"
-version = "0.30.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b4fea69e23de68c42c06769d6624d2d018da550c17244dd4b691f90ced4a7e"
+checksum = "b705f2c3643cc170d8888cb6bad589155d9c0248f3104ef7a04c2b7ffbaf13fc"
 dependencies = [
- "lazy_static",
+ "inventory",
+ "libloading",
+ "regex-lite",
  "rustler_codegen",
- "rustler_sys",
 ]
 
 [[package]]
 name = "rustler_codegen"
-version = "0.30.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406061bd07aaf052c344257afed4988c5ec8efe4d2352b4c2cf27ea7c8575b12"
+checksum = "3ad56caff00562948bd6ac33c18dbc579e5a1bbee2d7f2f54073307e57f6b57a"
 dependencies = [
  "heck",
+ "inventory",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "rustler_sys"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7c0740e5322b64e2b952d8f0edce5f90fcf6f6fe74cca3f6e78eb3de5ea858"
-dependencies = [
- "regex",
- "unreachable",
 ]
 
 [[package]]
@@ -168,16 +150,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
+name = "windows-targets"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "void",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
-name = "void"
-version = "1.0.2"
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/native/arrow_format_nif/Cargo.toml
+++ b/native/arrow_format_nif/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["dylib"]
 
 [dependencies]
 arrow-format = { version = "0.8", features = ["ipc"] }
-rustler = "0.30.0"
+rustler = "0.35.0"

--- a/native/arrow_format_nif/src/lib.rs
+++ b/native/arrow_format_nif/src/lib.rs
@@ -281,12 +281,4 @@ fn serialize_footer(env: Env, footer: Footer) -> Binary {
     erl_bin.release(env)
 }
 
-rustler::init!(
-    "arrow_format_nif",
-    [
-        test_decode,
-        test_encode,
-        serialize_message,
-        serialize_footer
-    ]
-);
+rustler::init!("arrow_format_nif");


### PR DESCRIPTION
I was getting a build error on my Mac, updating Rustler seems to fix it. This warning popped up after the upgrade, removing the code fixed the warning.
```
   Compiling arrow_format_nif v0.1.0 (/Users/mattpope/test/serde_arrow/native/arrow_format_nif)
warning: use of deprecated constant `rustler_init::explicit_nif_functions`: Passing NIF functions explicitly is deprecated and this argument is ignored, please remove it
   --> src/lib.rs:286:5
    |
286 | /     [
287 | |         test_decode,
288 | |         test_encode,
289 | |         serialize_message,
290 | |         serialize_footer
291 | |     ]
    | |_____^
    |
    = note: `#[warn(deprecated)]` on by default
```