### PR TITLE
Fix documentation deployment via GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,10 +64,10 @@ jobs:
         run: rebar3 ex_doc
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v7
         with:
           path: 'doc'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The GH Pages API tends to deprecate old version very often.
This commit fixes the docs action by updating the APIs.
