### PR TITLE
chore: Use approved GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,7 +59,7 @@ jobs:
             test-native-${{ runner.os }}-${{ env.RUST_TOOLCHAIN_VERSION }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,7 +64,7 @@ jobs:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
 
       - name: Install Erlang/OTP
-        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: 25.1.0
           rebar3-version: '3.18.0'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,12 +59,12 @@ jobs:
             test-native-${{ runner.os }}-${{ env.RUST_TOOLCHAIN_VERSION }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
 
       - name: Install Erlang/OTP
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93
         with:
           otp-version: 25.1.0
           rebar3-version: '3.18.0'

--- a/.github/workflows/erlang-ci.yml
+++ b/.github/workflows/erlang-ci.yml
@@ -72,7 +72,7 @@ jobs:
             test-native-${{ runner.os }}-${{ env.RUST_TOOLCHAIN_VERSION }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
 
@@ -143,7 +143,7 @@ jobs:
             test-native-${{ runner.os }}-${{ env.RUST_TOOLCHAIN_VERSION }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
 

--- a/.github/workflows/erlang-ci.yml
+++ b/.github/workflows/erlang-ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Erlang/OTP
-        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: 25.1.0
           rebar3-version: '3.18.0'
@@ -77,7 +77,7 @@ jobs:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
 
       - name: Install Erlang/OTP
-        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: 25.1.0
           rebar3-version: '3.18.0'
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Erlang/OTP
-        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: 25.1.0
           rebar3-version: '3.18.0'
@@ -148,7 +148,7 @@ jobs:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
 
       - name: Install Erlang/OTP
-        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: 25.1.0
           rebar3-version: '3.18.0'

--- a/.github/workflows/erlang-ci.yml
+++ b/.github/workflows/erlang-ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Erlang/OTP
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93
         with:
           otp-version: 25.1.0
           rebar3-version: '3.18.0'
@@ -72,12 +72,12 @@ jobs:
             test-native-${{ runner.os }}-${{ env.RUST_TOOLCHAIN_VERSION }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
 
       - name: Install Erlang/OTP
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93
         with:
           otp-version: 25.1.0
           rebar3-version: '3.18.0'
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Erlang/OTP
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93
         with:
           otp-version: 25.1.0
           rebar3-version: '3.18.0'
@@ -143,12 +143,12 @@ jobs:
             test-native-${{ runner.os }}-${{ env.RUST_TOOLCHAIN_VERSION }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
 
       - name: Install Erlang/OTP
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93
         with:
           otp-version: 25.1.0
           rebar3-version: '3.18.0'

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -69,7 +69,7 @@ jobs:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
           components: rustfmt
 
-      - uses: swatinem/rust-cache@v2 # v2.9.1
+      - uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           env-vars: "RUST_TOOLCHAIN_VERSION"
           workspaces: |
@@ -94,7 +94,7 @@ jobs:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
           components: rustfmt
 
-      - uses: swatinem/rust-cache@v2 # v2.9.1
+      - uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           env-vars: "RUST_TOOLCHAIN_VERSION"
           workspaces: |

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
           components: clippy
@@ -64,12 +64,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
           components: rustfmt
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: swatinem/rust-cache@v2
         with:
           env-vars: "RUST_TOOLCHAIN_VERSION"
           workspaces: |
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
           components: rustfmt

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -44,7 +44,7 @@ jobs:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: swatinem/rust-cache@v2
         with:
           env-vars: "RUST_TOOLCHAIN_VERSION"
           workspaces: |
@@ -94,7 +94,7 @@ jobs:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
           components: rustfmt
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: swatinem/rust-cache@v2
         with:
           env-vars: "RUST_TOOLCHAIN_VERSION"
           workspaces: |

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -39,12 +39,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
           components: clippy
 
-      - uses: swatinem/rust-cache@v2
+      - uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           env-vars: "RUST_TOOLCHAIN_VERSION"
           workspaces: |
@@ -64,12 +64,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
           components: rustfmt
 
-      - uses: swatinem/rust-cache@v2
+      - uses: swatinem/rust-cache@v2 # v2.9.1
         with:
           env-vars: "RUST_TOOLCHAIN_VERSION"
           workspaces: |
@@ -89,12 +89,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
           components: rustfmt
 
-      - uses: swatinem/rust-cache@v2
+      - uses: swatinem/rust-cache@v2 # v2.9.1
         with:
           env-vars: "RUST_TOOLCHAIN_VERSION"
           workspaces: |


### PR DESCRIPTION
## Which issue does this PR close?

Closes #50.

## Rationale for this change

The ASF has a list of approved GitHub Actions that are allowed to execute (found [here](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml)). Unless all actions in a workflow have been approved, the workflow cannot run.

## What's Changed

This commit pins certain actions to the approved version so that GitHub Actions can execute.
