### PR TITLE
chore: Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore: "
+    open-pull-requests-limit: 10
+  - package-ecosystem: "cargo"
+    directory: "/native/arrow_format_nif"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore: "
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## What issue does this PR close?

Closes #56.

## What changed

This commit enables dependabot for GitHub Actions and Cargo. Though the
Hex ecosystem is supported via Elixir's Mix, Rebar3 support for Erlang
is missing.
