### PR TITLE
chore: Perform ASF allowlist checks on CI changes

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -29,7 +29,7 @@ on:
       - ".github/**"
 
 concurrency:
-  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  group: ${{ github.repository }}-${{ github.head_ref || github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# See https://github.com/apache/iceberg/blob/main/.github/workflows/asf-allowlist-check.yml
+name: "GitHub Actions Checks"
+
+on:
+  pull_request:
+    paths:
+      - ".github/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gha:
+    name: "Analyze Actions"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+
+    # Check that actions are pinned and on the ASF allowlist.
+    # Intentionally unpinned to always use the latest allowlist from the ASF.
+    - uses: apache/infrastructure-actions/allowlist-check@main # zizmor: ignore[unpinned-uses]
+
+    # Analyze workflows with Zizmor
+    - name: Run zizmor 🌈
+      uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+      with:
+        advanced-security: false

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -40,16 +40,16 @@ jobs:
     name: "Analyze Actions"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        persist-credentials: false
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
-    # Check that actions are pinned and on the ASF allowlist.
-    # Intentionally unpinned to always use the latest allowlist from the ASF.
-    - uses: apache/infrastructure-actions/allowlist-check@main # zizmor: ignore[unpinned-uses]
+      # Check that actions are pinned and on the ASF allowlist.
+      # Intentionally unpinned to always use the latest allowlist from the ASF.
+      - uses: apache/infrastructure-actions/allowlist-check@main # zizmor: ignore[unpinned-uses]
 
-    # Analyze workflows with Zizmor
-    - name: Run zizmor 🌈
-      uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
-      with:
-        advanced-security: false
+      # Analyze workflows with Zizmor
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: false

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -23,8 +23,6 @@ on:
     paths:
       - ".github/**"
   push:
-    branches:
-      - main
     paths:
       - ".github/**"
 

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -47,9 +47,3 @@ jobs:
       # Check that actions are pinned and on the ASF allowlist.
       # Intentionally unpinned to always use the latest allowlist from the ASF.
       - uses: apache/infrastructure-actions/allowlist-check@main # zizmor: ignore[unpinned-uses]
-
-      # Analyze workflows with Zizmor
-      - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
-        with:
-          advanced-security: false


### PR DESCRIPTION
## What issue does this PR close?

Closes #70.

Dependabot updates do not respect the ASF allowlist. Thus, some dependabot PRs
can silently break workflows as seen in #63.

## What's changed

A workflow to perform to ASF allowlist checks on changes to `.github` has been
added. Any breakages introduced by dependabot updates (or any other changes)
will be highlighted.

Copied verbatim from https://github.com/apache/arrow-adbc/blob/main/.github/workflows/asf-allowlist-check.yml.
