### PR TITLE
fix: use stable tag for dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,7 +59,7 @@ jobs:
             test-native-${{ runner.os }}-${{ env.RUST_TOOLCHAIN_VERSION }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
 

--- a/.github/workflows/erlang-ci.yml
+++ b/.github/workflows/erlang-ci.yml
@@ -72,7 +72,7 @@ jobs:
             test-native-${{ runner.os }}-${{ env.RUST_TOOLCHAIN_VERSION }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
 
@@ -143,7 +143,7 @@ jobs:
             test-native-${{ runner.os }}-${{ env.RUST_TOOLCHAIN_VERSION }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.0
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
           components: clippy
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.0
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
           components: rustfmt
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.0
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
           components: rustfmt


### PR DESCRIPTION
## What issue does this PR close?

Doesn't close an issue tracked in the issue tracker.

Dependabot has not been updating `dtolnay/rust-toolchain` since I used to `v1` tag instead of the `stable` tag. The ASF allowlist moved forward to a new version and our CI started failing.

## What's changed

The tag has been corrected. The hash has also been bumped to the allowed version.