### PR TITLE
chore: Update links

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,7 +18,7 @@
 # https://github.com/apache/infrastructure-asfyaml
 github:
   description: "Official Erlang implementation of Apache Arrow"
-  homepage: https://arrow.apache.org/erlang/
+  homepage: https://arrow.apache.org/erlang/main/
   labels:
     - apache-arrow
     - erlang

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In addition to an Erlang installation, you will need a Rust installation with
 `cargo`. You can then add the following to your rebar.config:
 
 ``` erlang
-{arrow, {git, "https://github.com/Benjamin-Philip/arrow.git"}}
+{arrow, {git, "https://github.com/apache/arrow-erlang.git"}}
 ```
 
 And compile!

--- a/rebar.config
+++ b/rebar.config
@@ -41,8 +41,8 @@
         {"guides/quick-run-through.livemd", #{title => "Quick Run-Through Guide"}}
     ]},
     {main, "README.md"},
-    {homepage_url, "https://github.com/Benjamin-Philip/arrow"},
-    {source_url, "https://github.com/Benjamin-Philip/arrow"}
+    {homepage_url, "https://github.com/apache/arrow-erlang"},
+    {source_url, "https://github.com/apache/arrow-erlang"}
 ]}.
 
 {hex, [


### PR DESCRIPTION
## What issue does this PR close?

The current GitHub homepage link points to a non-existing Hexpm package. We can
revert to the current link once a package has been published in Hexpm.

Also, the README and the ExDoc documentation still used to old urls from before the transfer.

## What's changed

- `github.homepage` points to https://arrow.apache.org/erlang/main/
- ExDoc uses https://github.com/apache/arrow-erlang for both `homepage_url` and `source_url`
- README has been updated