### PR TITLE
chore: Remove Redundant 'CI' suffix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Docs CI
+name: Docs
 on:
   push:
   pull_request:

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Erlang CI
+name: Erlang
 on:
   push:
     branches:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Rust CI
+name: Rust
 on:
   push:
     branches:
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   lint-rust:
-    name: Lint Rust with Clippy
+    name: Lint with Clippy
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -59,7 +59,7 @@ jobs:
         run: cargo clippy --manifest-path=${{ matrix.manifest }} -- -Dwarnings
 
   fmt-rust:
-    name: Check Rust Formatting with rustfmt
+    name: Check Formatting with rustfmt
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## What issue does this PR fix?

The GitHub Actions workflows had a redundant 'CI' suffix in their title and filenames.

## What's changed

This suffix has been removed.