### PR TITLE
chore: Use swatinem/rust-cache action for caching Rust

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,22 +36,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache Rust crates
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: test-native-${{ runner.os }}-${{ env.RUST_TOOLCHAIN_VERSION }}-${{ hashFiles('native/**/Cargo.lock') }}
-          restore-keys: |
-            test-native-${{ runner.os }}-${{ env.RUST_TOOLCHAIN_VERSION }}
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
+
+      - name: Cache Rust packages
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          env-vars: "RUST_TOOLCHAIN_VERSION"
+          workspaces: |
+            native/arrow_format_nif
 
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -66,22 +66,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache Rust crates
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: test-native-${{ runner.os }}-${{ env.RUST_TOOLCHAIN_VERSION }}-${{ hashFiles('native/**/Cargo.lock') }}
-          restore-keys: |
-            test-native-${{ runner.os }}-${{ env.RUST_TOOLCHAIN_VERSION }}
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
+
+      - name: Cache Rust packages
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          env-vars: "RUST_TOOLCHAIN_VERSION"
+          workspaces: |
+            native/arrow_format_nif
 
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
@@ -111,6 +106,18 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
+
+      - name: Cache Rust packages
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          env-vars: "RUST_TOOLCHAIN_VERSION"
+          workspaces: |
+            native/arrow_format_nif
 
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1


### PR DESCRIPTION
## What's Changed

Uses swatinem/rust-cache for effectively caching Rust. Removes any manual
caching. This will potentially lead to faster CIs since compiling Rust is the
most time intensive common step.