### PR TITLE
chore: Replace dtolnay/rust-toolchain with rustup

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,9 +22,6 @@ on:
 
   workflow_dispatch:
 
-env:
-  RUST_TOOLCHAIN_VERSION: stable
-
 jobs:
   build:
     name: Build Docs
@@ -37,14 +34,11 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
-        with:
-          toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
+        run: cd ./native/arrow_format_nif/ && rustup toolchain install
 
       - name: Cache Rust packages
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          env-vars: "RUST_TOOLCHAIN_VERSION"
           workspaces: |
             native/arrow_format_nif
 

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -67,9 +67,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
-        with:
-          toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
+        run: cd ./native/arrow_format_nif/ && rustup toolchain install
 
       - name: Cache Rust packages
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -108,9 +106,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
-        with:
-          toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
+        run: cd ./native/arrow_format_nif/ && rustup toolchain install
 
       - name: Cache Rust packages
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,9 +24,6 @@ on:
     branches:
       - main
 
-env:
-  RUST_TOOLCHAIN_VERSION: stable
-
 permissions:
   contents: read
 
@@ -44,14 +41,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
-        with:
-          toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
-          components: clippy
+      - name: Install Rust
+        run: cd ./native/arrow_format_nif/ && rustup toolchain install
 
       - uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          env-vars: "RUST_TOOLCHAIN_VERSION"
           workspaces: |
             native/arrow_format_nif
 
@@ -71,14 +65,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
-        with:
-          toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
-          components: rustfmt
+      - name: Install Rust
+        run: cd ./native/arrow_format_nif/ && rustup toolchain install
 
       - uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          env-vars: "RUST_TOOLCHAIN_VERSION"
           workspaces: |
             native/arrow_format_nif
 
@@ -98,14 +89,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
-        with:
-          toolchain: "${{ env.RUST_TOOLCHAIN_VERSION }}"
-          components: rustfmt
+      - name: Install Rust
+        run: cd ./native/arrow_format_nif/ && rustup toolchain install
 
       - uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          env-vars: "RUST_TOOLCHAIN_VERSION"
           workspaces: |
             native/arrow_format_nif
 

--- a/native/arrow_format_nif/rust-toolchain.toml
+++ b/native/arrow_format_nif/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["clippy", "rustfmt"]

--- a/native/arrow_format_nif/rust-toolchain.toml
+++ b/native/arrow_format_nif/rust-toolchain.toml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [toolchain]
 channel = "stable"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## What issue does this PR close?

Closes #107.

The dtolnay/rust-toolchain has been causing many problems because of its
non-standard release practices, breaking Dependabot updates as well as the CI.
See the issue for more context.

## What's Changed

A `rust-toolchain.toml` file has been added detailing exactly what we need. The
necessary rust compiler and components are now installed via a `rustup toolchain
install`. This is more in line with the process in the arrow-rs project.