### PR TITLE
fix: arrow_buffer:size/1 use 64 byte padding not 8

### DIFF
--- a/native/arrow_format_nif/src/lib.rs
+++ b/native/arrow_format_nif/src/lib.rs
@@ -168,39 +168,39 @@ pub mod test {
                                 length: 1,
                             },
                             ipc::Buffer {
-                                offset: 8,
+                                offset: 64,
                                 length: 4,
                             },
                             ipc::Buffer {
-                                offset: 16,
+                                offset: 128,
                                 length: 1,
                             },
                             ipc::Buffer {
-                                offset: 24,
+                                offset: 192,
                                 length: 20,
                             },
                             ipc::Buffer {
-                                offset: 48,
+                                offset: 256,
                                 length: 15,
                             },
                             ipc::Buffer {
-                                offset: 64,
+                                offset: 320,
                                 length: 1,
                             },
                             ipc::Buffer {
-                                offset: 72,
+                                offset: 384,
                                 length: 4,
                             },
                             ipc::Buffer {
-                                offset: 80,
+                                offset: 448,
                                 length: 1,
                             },
                             ipc::Buffer {
-                                offset: 88,
+                                offset: 512,
                                 length: 2,
                             },
                             ipc::Buffer {
-                                offset: 96,
+                                offset: 576,
                                 length: 10,
                             },
                         ]),

--- a/native/arrow_format_nif/src/utils.rs
+++ b/native/arrow_format_nif/src/utils.rs
@@ -120,39 +120,39 @@ pub fn record_batch() -> Message {
                     length: 1,
                 },
                 Buffer {
-                    offset: 8,
+                    offset: 64,
                     length: 4,
                 },
                 Buffer {
-                    offset: 16,
+                    offset: 128,
                     length: 1,
                 },
                 Buffer {
-                    offset: 24,
+                    offset: 192,
                     length: 20,
                 },
                 Buffer {
-                    offset: 48,
+                    offset: 256,
                     length: 15,
                 },
                 Buffer {
-                    offset: 64,
+                    offset: 320,
                     length: 1,
                 },
                 Buffer {
-                    offset: 72,
+                    offset: 384,
                     length: 4,
                 },
                 Buffer {
-                    offset: 80,
+                    offset: 448,
                     length: 1,
                 },
                 Buffer {
-                    offset: 88,
+                    offset: 512,
                     length: 2,
                 },
                 Buffer {
-                    offset: 96,
+                    offset: 576,
                     length: 10,
                 },
             ],

--- a/src/arrow_buffer.erl
+++ b/src/arrow_buffer.erl
@@ -119,8 +119,8 @@ to_erlang(_Buffer) ->
 -doc "Returns the size of the buffer inclusive of padding in bytes.".
 -spec size(Buffer :: arrow_buffer:buffer()) -> pos_integer().
 size(Buffer) ->
-    Len = Buffer#buffer.length * 8,
-    round((Len + arrow_utils:pad_len(Len)) / 8).
+    Len = Buffer#buffer.length,
+    Len + arrow_utils:pad_len(Len).
 
 -spec slot(
     Value :: arrow_type:native_type(),

--- a/src/arrow_buffer.erl
+++ b/src/arrow_buffer.erl
@@ -117,7 +117,7 @@ to_erlang(_Buffer) ->
     erlang:error(badarg).
 
 -doc "Returns the size of the buffer inclusive of padding in bytes.".
--spec size(Buffer :: arrow_buffer:buffer()) -> pos_integer().
+-spec size(Buffer :: arrow_buffer:buffer()) -> non_neg_integer().
 size(Buffer) ->
     Len = Buffer#buffer.length,
     Len + arrow_utils:pad_len(Len).

--- a/test/arrow_buffer_SUITE.erl
+++ b/test/arrow_buffer_SUITE.erl
@@ -157,7 +157,7 @@ to_erlang(_Config) ->
 
 size(_Config) ->
     Buffer = arrow_buffer:from_erlang([1, 2, 3], {s, 8}),
-    ?assertEqual(arrow_buffer:size(Buffer), 8).
+    ?assertEqual(arrow_buffer:size(Buffer), byte_size(arrow_buffer:to_arrow(Buffer))).
 
 %%%%%%%%%%%
 %% Utils %%

--- a/test/arrow_ipc_record_batch_SUITE.erl
+++ b/test/arrow_ipc_record_batch_SUITE.erl
@@ -43,14 +43,19 @@ valid_nodes_on_from_erlang(_Config) ->
     ?assertEqual((?RecordBatch)#record_batch.nodes, FieldNodes).
 
 valid_buffers_on_from_erlang(_Config) ->
-    ID = [#{offset => 0, length => 1}, #{offset => 8, length => 4}],
+    ID = [#{offset => 0, length => 1}, #{offset => 64, length => 4}],
     Name = [
-        #{offset => 16, length => 1}, #{offset => 24, length => 20}, #{offset => 48, length => 15}
+        #{offset => 128, length => 1},
+        #{offset => 192, length => 20},
+        #{offset => 256, length => 15}
     ],
-    Age = [#{offset => 64, length => 1}, #{offset => 72, length => 4}],
+    Age = [#{offset => 320, length => 1}, #{offset => 384, length => 4}],
     Marks =
-        [#{offset => 80, length => 1}] ++
-            [#{offset => 88, length => 2}, #{offset => 96, length => 10}],
+        [
+            #{offset => 448, length => 1},
+            #{offset => 512, length => 2},
+            #{offset => 576, length => 10}
+        ],
     Buffers = ID ++ Name ++ Age ++ Marks,
 
     ?assertEqual((?RecordBatch)#record_batch.buffers, Buffers).


### PR DESCRIPTION
## What issue does this PR close?

Closes #113.

Previously, arrow_buffer:size/1 took 8 byte padding to calculate size
when the buffers actually used 64 bytes. This resulted in various gross
errors in offsets and other metadata, rendering any IPC binaries
produced unusable.

## What's Changed

`arrow_buffer:size/1` now correctly uses 64 byte padding. Record Batch test data
has been updated with the correct offsets.